### PR TITLE
Fix depend target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@ all: depend generate compile images
 check: depend gofmt vet gometalinter
 
 depend: ## Sync vendor directory by running dep ensure
-	dep version || go get -u github.com/golang/dep/cmd/dep
-	dep ensure -v
+	$$GOPATH/bin/dep version || go get -u github.com/golang/dep/cmd/dep
+	$$GOPATH/bin/dep ensure -v
 
 depend-update: ## Update all dependencies
-	dep ensure -update -v
+	$$GOPATH/bin/dep version || go get -u github.com/golang/dep/cmd/dep
+	$$GOPATH/bin/dep ensure -update -v
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
**What this PR does / why we need it**:

This tries to fix Prow error with depend and `dep` not being found.

**Release note**:

```release-note
NONE
```