### PR TITLE
Makefile: add lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,8 @@ gofmt: ## Go fmt your code
 vet: ## Apply go vet to all go files
 	go vet ./...
 
-gometalinter: ## Run gometalinter on all go files
-	gometalinter --version || go get -u gopkg.in/alecthomas/gometalinter.v2
-	gometalinter --install
-	gometalinter --config gometalinter.json ./...
+lint: ## Run gometalinter on all go files
+	gometalinter --config gometalinter.json ./... --deadline 20m
 
 .PHONY: help
 help:  ## Show help messages for make targets


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `lint` target in the Makefile. The content below this line shows the original PR body.

---

To fix the path error in the lint prowjob. The error can be see [here](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-digitalocean/120/pull-cluster-api-provider-digitalocean-lint/12/build-log.txt).

The error is:

```
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_bazel.py", line 275, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_bazel.py", line 141, in main
    raise ValueError('Invalid install path: %s' % install)
ValueError: Invalid install path: gubernator/test_requirements.txt
```

This occurs because it can't find `gubernator/test_requirements.txt` in this repo. This actually existed in the test-infra repo: https://github.com/kubernetes/test-infra/blob/master/gubernator/test_requirements.txt. We need to also add it in this repo.

https://github.com/kubernetes/test-infra/pull/10206 updates the prowjob in test-infra. Once that's merged, tests should pass for this PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```