### PR TITLE
Remove nikhita as cluster-api-do-maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,5 +14,4 @@ aliases:
   cluster-api-do-maintainers:
     - andrewsykim
     - alvaroaleman
-    - nikhita
     - xmudrii


### PR DESCRIPTION
I don't have the bandwidth for reviews right now.

/cc @xmudrii 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```