### PR TITLE
Remove andrewsykim from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - sig-cluster-lifecycle-leads
-  - sig-cloud-provider-leads
   - cluster-api-admins
   - cluster-api-maintainers
   - cluster-api-do-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,8 +16,5 @@ aliases:
     - ncdc
     - vincepri
     - chuckha
-  sig-cloud-provider-leads:
-    - andrewsykim
   cluster-api-do-maintainers:
-    - andrewsykim
     - xmudrii


### PR DESCRIPTION
**What this PR does / why we need it**:

@andrewsykim doesn't have the capacity to be active here and decided to step down as a maintainer.

**Release note**:
```release-note
NONE
```

/assign @andrewsykim 