### PR TITLE
Update OWNERS file to match CAPI OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,9 @@ approvers:
   - sig-cluster-lifecycle-leads
   - sig-cloud-provider-leads
   - cluster-api-admins
+  - cluster-api-maintainers
   - cluster-api-do-maintainers
 
 reviewers:
+  - cluster-api-maintainers
   - cluster-api-do-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,20 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
+    - neolit123
     - justinsb
-    - luxas
     - timothysc
   cluster-api-admins:
-    - davidewatson
-    - detiber
     - justinsb
+    - detiber
+    - davidewatson
+    - vincepri
+  cluster-api-maintainers:
+    - justinsb
+    - detiber
+    - ncdc
+    - vincepri
+    - chuckha
   sig-cloud-provider-leads:
     - andrewsykim
   cluster-api-do-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the OWNERS file to match Cluster-API and CAPI-AWS OWNERS.

**Release note**:
```release-note
NONE
```