### PR TITLE
Add cpanato and prksu as maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,4 +17,6 @@ aliases:
     - vincepri
     - chuckha
   cluster-api-do-maintainers:
+    - cpanato
+    - prksu
     - xmudrii


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds @cpanato and @prksu as Cluster-API DO maintainers.

TODO: create a PR to add them to test-infra OWNERS and GitHub teams.

**Release note**:
```release-note
NONE
```

/assign @cpanato @prksu
/hold
for lazy consensus until 3/25 EOD
~until https://github.com/kubernetes/org/issues/1725 is not merged~