### PR TITLE
Fix README typo and link to cloud-init doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ previous cluster managers such as [kops][kops] and
 
 ## Project Status
 
-This project is currently work-in-progress and in Alpha, so it may not be production ready. There is no backwards-compatibility guarantee at this point. For more details on the roadmap and upcoming features, check out [the project's issue tracker on GitHub][issue].
+This project is currently a work-in-progress, in an Alpha state, so it may not be production ready. There is no backwards-compatibility guarantee at this point. For more details on the roadmap and upcoming features, check out [the project's issue tracker on GitHub][issue].
 
 ## Launching a Kubernetes cluster on DigitalOcean
 
-Check out the [getting started guide](./docs/getting-started.md) for launching a cluster on DigitalOcean. 
+Check out the [getting started guide](./docs/getting-started.md) for launching a cluster on DigitalOcean.
 
 ## Features
 
 - Native Kubernetes manifests and API
 - Support for single and multi-node control plane clusters
-- Choice your Linux distribution (as long as a current cloud-init is available)
+- Choice of Linux distribution (as long as a current [cloud-init](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) is available)
 
 ------
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes some grammatical typos.
- Adds a link to `cloud-init`, which points to a cloud config example in their docs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```