### PR TITLE
Initial e2e-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= Always
 
+# Enable docker buildkit as default for better build performance.
+DOCKER_BUILDKIT ?= 1
+export DOCKER_BUILDKIT
+
 ## --------------------------------------
 ##@ Help
 ## --------------------------------------
@@ -75,7 +79,7 @@ help:  ## Display this help
 
 .PHONY: test
 test: generate lint ## Run tests
-	go test -v ./...
+	go test -v ./api/... ./controllers/... ./pkg/...
 
 .PHONY: test-integration
 test-integration: ## Run integration tests
@@ -84,12 +88,12 @@ test-integration: ## Run integration tests
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests
 	PULL_POLICY=IfNotPresent $(MAKE) docker-build
-	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=3h . -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	go test -v -timeout=1h ./$(TEST_E2E_DIR) -args -ginkgo.v -ginkgo.focus "functional tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
-.PHONY: test-conformance
-test-conformance: ## Run conformance test on workload cluster
+.PHONY: test-conformance	
+test-conformance: ## Run conformance test on workload cluster	
 	PULL_POLICY=IfNotPresent $(MAKE) docker-build
-	cd $(TEST_E2E_DIR); go test -v -tags=e2e -timeout=4h . -args -ginkgo.v -ginkgo.focus "conformance tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	go test -v -timeout=2h ./$(TEST_E2E_DIR) -args -ginkgo.v -ginkgo.focus "conformance tests" --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 ## --------------------------------------
 ##@ Binaries

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,9 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
-	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.8.1
-	go.uber.org/atomic v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 // indirect
@@ -26,5 +23,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/cluster-api v0.2.9
+	sigs.k8s.io/cluster-api/bootstrap/kubeadm v0.0.0-20191016155141-23a891785b60
 	sigs.k8s.io/controller-runtime v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -159,6 +161,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+AfE52mFHOXVFnOSBJBRlzTHrOPLOIhE=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 h1:uHTyIjqVhYRhLbJ8nIiOJHkEZZ+5YoOsAbD3sk82NiE=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -220,6 +223,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
+github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.0.0-20141017032234-72f9bd7c4e0c/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -315,6 +320,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
+github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -389,6 +396,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -419,6 +427,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190909003024-a7b16738d86b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -448,6 +457,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190911201528-7ad0cfa0b7b5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -555,6 +565,8 @@ k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=
 k8s.io/client-go v0.17.2/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=
+k8s.io/cluster-bootstrap v0.0.0-20190516232516-d7d78ab2cfe7 h1:5wvjieVoU4oovHlkeD256q2M2YYi2P01zk6wxSR2zk0=
+k8s.io/cluster-bootstrap v0.0.0-20190516232516-d7d78ab2cfe7/go.mod h1:iBSm2nwo3OaiuW8VDvc3ySDXK5SKfUrxwPvBloKG7zg=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269 h1:d8Fm55A+7HOczX58+x9x+nJnJ1Devt1aCrWVIPaw/Vg=
 k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269/go.mod h1:V5BD6M4CyaN5m+VthcclXWsVcT1Hu+glwa1bi3MIsyE=
@@ -591,8 +603,11 @@ modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
+sigs.k8s.io/cluster-api v0.2.5/go.mod h1:Agc72Ra5LMOkQQ2v/Ywv1KUemaYAwvkQ+G59Ym5H8e4=
 sigs.k8s.io/cluster-api v0.2.9 h1:PZSuz8hE1u5Y5lZcxi3pDDOc9xxY68uzxVoNGerEXy8=
 sigs.k8s.io/cluster-api v0.2.9/go.mod h1:BCw+Pqy1sc8mQ/3d2NZM/f5BApKFCMPsnGvKolvDcA0=
+sigs.k8s.io/cluster-api/bootstrap/kubeadm v0.0.0-20191016155141-23a891785b60 h1:xs/iNeNQwDa6W1RzY/xAxUQkUN6yH+JvENKQiGubfWc=
+sigs.k8s.io/cluster-api/bootstrap/kubeadm v0.0.0-20191016155141-23a891785b60/go.mod h1:d4Nz7rDBVC32CbS9xC4RQkTZTtpn5oQHuGWp7Vj/o3k=
 sigs.k8s.io/controller-runtime v0.3.0/go.mod h1:Cw6PkEg0Sa7dAYovGT4R0tRkGhHXpYijwNxYhAnAZZk=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,30 @@
+# E2E Test
+
+This document is to help developers understand how for run e2e test CAPDO.
+
+## Requirements
+
+In order to run the e2e tests the following requirements must be met:
+
+* Ginkgo
+* Docker
+* Kind v0.6.0+ (*Kind v0.7.0+ not working due upstream dependencies*)
+
+### Environment variables
+
+The first step to running the e2e tests is setting up the required environment variables:
+
+| Environment variable          | Description                                                                                           |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `DIGITALOCEAN_ACCESS_TOKEN`   | The DigitalOcean API V2 access token                                                                  |
+| `MACHINE_TYPE`                | The DigitalOcean Droplet size                                                                         |
+| `MACHINE_IMAGE`               | The DigitalOcean Image id or slug                                                                     |
+| `MACHINE_SSHKEY`              | The ssh key id or fingerprint (Should already registered in the DigitalOcean Account)                 |
+
+### Running e2e test
+
+In the root project directory run:
+
+```
+make test-e2e
+```

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	bootstrapkubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+)
+
+var _ = Describe("functional tests", func() {
+	Describe("cluster lifecycle", func() {
+		var (
+			clusterName        string
+			clusterNamespace   string
+			clusterGenenerator ClusterGenerator
+			machineGenerator   MachineGenerator
+		)
+
+		BeforeEach(func() {
+			var err error
+			clusterName = "capdo-test-" + util.RandomString(6)
+			clusterNamespace = "default"
+
+			testTmpDir, err = ioutil.TempDir(suiteTmpDir, "e2e-test")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("Single control plane with one worker node", func() {
+			It("It should be creatable and deletable", func() {
+				By("Create a cluster")
+				cluster, docluster := clusterGenenerator.Generate(clusterNamespace, clusterName)
+				createCluster(cluster, docluster)
+
+				By("Create a single controlplane")
+				controlPlaneMachine, controlPlaneKubeadmconfig, controlPlaneDomachine := machineGenerator.Generate(clusterNamespace, clusterName, true)
+				createMachine(controlPlaneMachine, controlPlaneKubeadmconfig, controlPlaneDomachine)
+
+				By("Ensuring Cluster Controlplane Initialized")
+				WaitForClusterControlplaneInitialized(kindclient, cluster.Namespace, cluster.Name)
+
+				By("Exporting Cluster kubeconfig")
+				kubeConfigData, err := kubeconfig.FromSecret(kindclient, cluster)
+				Expect(err).NotTo(HaveOccurred())
+				kubeConfigPath := path.Join(testTmpDir, clusterName+".kubeconfig")
+				Expect(ioutil.WriteFile(kubeConfigPath, kubeConfigData, 0640)).To(Succeed())
+
+				By("Deploying CNI")
+				ApplyYaml(kubeConfigPath, "https://docs.projectcalico.org/manifests/calico.yaml")
+
+				By("Deploying Cloud Controller Manager")
+				var ccmManifest string
+				buildCloudControllerManager(&ccmManifest)
+				ApplyYaml(kubeConfigPath, ccmManifest)
+
+				By("Create one worker")
+				workerMachine, workerKubeadmconfig, workerDomachine := machineGenerator.Generate(clusterNamespace, clusterName, false)
+				createMachine(workerMachine, workerKubeadmconfig, workerDomachine)
+
+				By("Delete worker")
+				deleteMachine(workerMachine, workerKubeadmconfig, workerDomachine)
+
+				By("Delete controlplane")
+				deleteMachine(controlPlaneMachine, controlPlaneKubeadmconfig, controlPlaneDomachine)
+
+				By("Delete cluster")
+				deleteCluster(cluster, docluster)
+			})
+		})
+	})
+})
+
+func createCluster(cluster *clusterv1.Cluster, docluster *infrav1.DOCluster) {
+	By("Creating a Cluster")
+	Expect(kindclient.Create(context.TODO(), cluster)).To(Succeed())
+
+	By("Creating a DOCluster")
+	Expect(kindclient.Create(context.TODO(), docluster)).To(Succeed())
+
+	By("Ensuring Cluster Infrastructure is Ready")
+	WaitForClusterInfrastructureReady(kindclient, cluster.Namespace, cluster.Name)
+}
+
+func deleteCluster(cluster *clusterv1.Cluster, docluster *infrav1.DOCluster) {
+	By("Deleting a DOCluster")
+	Expect(kindclient.Delete(context.TODO(), docluster)).To(Succeed())
+	WaitForDeletion(kindclient, docluster, docluster.Namespace, docluster.Name)
+
+	By("Deleting a Cluster")
+	Expect(kindclient.Delete(context.TODO(), cluster)).To(Succeed())
+	WaitForDeletion(kindclient, cluster, cluster.Namespace, cluster.Name)
+}
+
+func createMachine(machine *clusterv1.Machine, kubeadmConfig *bootstrapkubeadmv1.KubeadmConfig, domachine *infrav1.DOMachine) {
+	role := "worker"
+	if util.IsControlPlaneMachine(machine) {
+		role = "controlplane"
+	}
+
+	By(fmt.Sprintf("Creating %s KubeadmConfig", role))
+	Expect(kindclient.Create(context.TODO(), kubeadmConfig)).To(Succeed())
+
+	By(fmt.Sprintf("Creating %s DOMachine", role))
+	Expect(kindclient.Create(context.TODO(), domachine)).To(Succeed())
+
+	By(fmt.Sprintf("Creating %s Machine", role))
+	Expect(kindclient.Create(context.TODO(), machine)).To(Succeed())
+
+	By(fmt.Sprintf("Ensuring %s Machine Bootstrap is Ready", role))
+	WaitForMachineBootstrapReady(kindclient, machine.Namespace, machine.Name)
+
+	By(fmt.Sprintf("Ensuring %s DOMachine is Running", role))
+	WaitForDOMachineRunning(kindclient, domachine.Namespace, domachine.Name)
+
+	By(fmt.Sprintf("Ensuring %s DOMachine is Ready", role))
+	WaitForDOMachineReady(kindclient, domachine.Namespace, domachine.Name)
+
+	By(fmt.Sprintf("Ensuring %s MachineNodeRef is Already Set", role))
+	WaitForMachineNodeRef(kindclient, machine.Namespace, machine.Name)
+}
+
+func deleteMachine(machine *clusterv1.Machine, kubeadmConfig *bootstrapkubeadmv1.KubeadmConfig, domachine *infrav1.DOMachine) {
+	role := "worker"
+	if util.IsControlPlaneMachine(machine) {
+		role = "controlplane"
+	}
+
+	By(fmt.Sprintf("Deleting %s KubeadmConfig", role))
+	Expect(kindclient.Delete(context.TODO(), kubeadmConfig)).To(Succeed())
+	WaitForDeletion(kindclient, kubeadmConfig, kubeadmConfig.Namespace, kubeadmConfig.Name)
+
+	By(fmt.Sprintf("Deleting %s DOMachine", role))
+	Expect(kindclient.Delete(context.TODO(), domachine)).To(Succeed())
+	WaitForDeletion(kindclient, domachine, domachine.Namespace, domachine.Name)
+
+	By(fmt.Sprintf("Deleting %s Machine", role))
+	Expect(kindclient.Delete(context.TODO(), machine)).To(Succeed())
+	WaitForDeletion(kindclient, machine, machine.Namespace, machine.Name)
+}

--- a/test/e2e/manifests/digitalocean-cloud-controller-manager.yaml
+++ b/test/e2e/manifests/digitalocean-cloud-controller-manager.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: digitalocean
+  namespace: kube-system
+stringData:
+  access-token: ${DIGITALOCEAN_ACCESS_TOKEN}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: digitalocean-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: digitalocean-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: digitalocean-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      serviceAccountName: cloud-controller-manager
+      dnsPolicy: Default
+      hostNetwork: true
+      tolerations:
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+      containers:
+      - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.22
+        name: digitalocean-cloud-controller-manager
+        command:
+          - "/bin/digitalocean-cloud-controller-manager"
+          - "--leader-elect=true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: KUBERNETES_SERVICE_PORT
+            value: "6443"
+          - name: DO_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: digitalocean
+                key: access-token
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system

--- a/test/e2e/resource_generator.go
+++ b/test/e2e/resource_generator.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	bootstrapkubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha2"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/kubeadm/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+type ClusterGenerator struct{}
+
+func (gen ClusterGenerator) Generate(clusterNamespace, clusterName string) (*clusterv1.Cluster, *infrav1.DOCluster) {
+	clusterRegion := "nyc1"
+	docluster := &infrav1.DOCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: infrav1.DOClusterSpec{
+			Region: clusterRegion,
+		},
+	}
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: clusterv1.ClusterSpec{
+			ClusterNetwork: &clusterv1.ClusterNetwork{},
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       TypeToKind(docluster),
+				Namespace:  docluster.GetNamespace(),
+				Name:       docluster.GetName(),
+			},
+		},
+	}
+
+	return cluster, docluster
+}
+
+type MachineGenerator struct{}
+
+func (gen MachineGenerator) Generate(namespace, clusterName string, isControlPlane bool) (*clusterv1.Machine, *bootstrapkubeadmv1.KubeadmConfig, *infrav1.DOMachine) {
+	name := clusterName + "-node-" + util.RandomString(6)
+	if isControlPlane {
+		name = clusterName + "-controlplane-" + util.RandomString(6)
+	}
+
+	kubernetesVersion := *kubernetesVersion
+	kubeadmconfig := &bootstrapkubeadmv1.KubeadmConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: bootstrapkubeadmv1.KubeadmConfigSpec{
+			InitConfiguration: &kubeadmv1beta1.InitConfiguration{
+				NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+					Name: `{{ ds.meta_data["local_hostname"] }}`,
+					KubeletExtraArgs: map[string]string{
+						"cloud-provider": "external",
+						"provider-id":    `digitalocean://{{ ds.meta_data["instance_id"] }}`,
+					},
+				},
+			},
+			JoinConfiguration: &kubeadmv1beta1.JoinConfiguration{
+				NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+					Name: `{{ ds.meta_data["local_hostname"] }}`,
+					KubeletExtraArgs: map[string]string{
+						"cloud-provider": "external",
+						"provider-id":    `digitalocean://{{ ds.meta_data["instance_id"] }}`,
+					},
+				},
+			},
+		},
+	}
+
+	domachine := &infrav1.DOMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: infrav1.DOMachineSpec{
+			Size:           machineSize,
+			Image:          intstr.Parse(machineImage),
+			SSHKeys:        []intstr.IntOrString{intstr.Parse(machineSSHKey)},
+			AdditionalTags: infrav1.Tags{"e2e-test"},
+		},
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				clusterv1.MachineClusterLabelName: clusterName,
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: bootstrapkubeadmv1.GroupVersion.String(),
+					Kind:       TypeToKind(kubeadmconfig),
+					Namespace:  kubeadmconfig.GetNamespace(),
+					Name:       kubeadmconfig.GetName(),
+				},
+			},
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       TypeToKind(domachine),
+				Namespace:  domachine.GetNamespace(),
+				Name:       domachine.GetName(),
+			},
+			Version: &kubernetesVersion,
+		},
+	}
+
+	if isControlPlane {
+		machine.ObjectMeta.Labels = labels.Merge(machine.ObjectMeta.Labels, map[string]string{
+			clusterv1.MachineControlPlaneLabelName: "true",
+		})
+	}
+
+	return machine, kubeadmconfig, domachine
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
+
+	bootstrapkubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/test/helpers/components"
+	capiFlag "sigs.k8s.io/cluster-api/test/helpers/flag"
+	"sigs.k8s.io/cluster-api/test/helpers/kind"
+	"sigs.k8s.io/cluster-api/test/helpers/scheme"
+	"sigs.k8s.io/cluster-api/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CAPIVERSION  = "v0.2.9"
+	CABPKVERSION = "v0.1.6"
+
+	capiNamespace       = "capi-system"
+	capiDeploymentName  = "capi-controller-manager"
+	cabpkNamespace      = "cabpk-system"
+	cabpkDeploymentName = "cabpk-controller-manager"
+	capdoNamespace      = "capdo-system"
+	capdoDeploymentName = "capdo-controller-manager"
+	setupTimeout        = 10 * 60
+)
+
+var (
+	managerImage      = capiFlag.DefineOrLookupStringFlag("managerImage", "", "Docker image to load into the kind cluster for testing")
+	capiComponents    = capiFlag.DefineOrLookupStringFlag("capiComponents", "https://github.com/kubernetes-sigs/cluster-api/releases/download/"+CAPIVERSION+"/cluster-api-components.yaml", "URL to CAPI components to load")
+	cabpkComponents   = capiFlag.DefineOrLookupStringFlag("cabpkComponents", "https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/"+CABPKVERSION+"/bootstrap-components.yaml", "URL to CAPI components to load")
+	capdoComponents   = capiFlag.DefineOrLookupStringFlag("capdoComponents", "", "capdo components to load")
+	kustomizeBinary   = capiFlag.DefineOrLookupStringFlag("kustomizeBinary", "kustomize", "path to the kustomize binary")
+	kubernetesVersion = capiFlag.DefineOrLookupStringFlag("kubernetesVersion", "v1.16.2", "kubernetes version to test on")
+
+	kindcluster kind.Cluster
+	kindclient  crclient.Client
+	suiteTmpDir string
+	testTmpDir  string
+
+	credentials   string
+	machineSize   string
+	machineImage  string
+	machineSSHKey string
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	// If running in prow, output the junit files to the artifacts path
+	junitPath := fmt.Sprintf("junit.e2e_suite.%d.xml", config.GinkgoConfig.ParallelNode)
+	artifactPath, exists := os.LookupEnv("ARTIFACTS")
+	if exists {
+		junitPath = path.Join(artifactPath, junitPath)
+	}
+	junitReporter := reporters.NewJUnitReporter(junitPath)
+	RunSpecsWithDefaultAndCustomReporters(t, "e2e Suite", []Reporter{junitReporter})
+}
+
+var _ = BeforeSuite(func() {
+	fmt.Fprintf(GinkgoWriter, "Verify required env variable\n")
+	credentials = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	Expect(credentials).NotTo(BeEmpty())
+	machineSize = os.Getenv("MACHINE_TYPE")
+	Expect(machineSize).NotTo(BeEmpty())
+	machineImage = os.Getenv("MACHINE_IMAGE")
+	Expect(machineImage).NotTo(BeEmpty())
+	machineSSHKey = os.Getenv("MACHINE_SSHKEY")
+	Expect(machineSSHKey).NotTo(BeEmpty())
+
+	fmt.Fprintf(GinkgoWriter, "Setting up kind cluster\n")
+	var err error
+	suiteTmpDir, err = ioutil.TempDir("", "capdo-e2e-suite")
+	Expect(err).NotTo(HaveOccurred())
+
+	s := scheme.SetupScheme()
+	Expect(bootstrapkubeadmv1.AddToScheme(s)).To(Succeed())
+	Expect(infrav1.AddToScheme(s)).To(Succeed())
+
+	kindcluster = kind.Cluster{
+		Name: "capdo-e2e-test-" + util.RandomString(6),
+	}
+
+	kindcluster.Setup()
+	kindcluster.LoadImage(*managerImage)
+
+	kindclient, err = crclient.New(kindcluster.RestConfig(), crclient.Options{Scheme: s})
+	Expect(err).NotTo(HaveOccurred())
+
+	kindcluster.ApplyYAML(*capiComponents)
+	kindcluster.ApplyYAML(*cabpkComponents)
+
+	if capdoComponents == nil || *capdoComponents == "" {
+		buildCAPDOComponents(capdoComponents)
+	}
+	kindcluster.ApplyYAML(*capdoComponents)
+
+	components.WaitDeployment(kindclient, capiNamespace, capiDeploymentName)
+	components.WaitDeployment(kindclient, cabpkNamespace, cabpkDeploymentName)
+	components.WaitDeployment(kindclient, capdoNamespace, capdoDeploymentName)
+
+	// Recreate kindclient so that it knows about the cluster api types
+	kindclient, err = crclient.New(kindcluster.RestConfig(), crclient.Options{Scheme: s})
+	Expect(err).NotTo(HaveOccurred())
+}, setupTimeout)
+
+var _ = AfterSuite(func() {
+	fmt.Fprintf(GinkgoWriter, "Tearing down kind cluster\n")
+	capiLogs := retrieveLogs(capiNamespace, capiDeploymentName)
+	cabpkLogs := retrieveLogs(cabpkNamespace, cabpkDeploymentName)
+	capdoLogs := retrieveLogs(capdoNamespace, capdoDeploymentName)
+
+	// If running in prow, output the logs to the artifacts path
+	artifactPath, exists := os.LookupEnv("ARTIFACTS")
+	if exists {
+		ioutil.WriteFile(path.Join(artifactPath, "capi.log"), []byte(capiLogs), 0644)   // nolint
+		ioutil.WriteFile(path.Join(artifactPath, "cabpk.log"), []byte(cabpkLogs), 0644) // nolint
+		ioutil.WriteFile(path.Join(artifactPath, "capdo.log"), []byte(capdoLogs), 0644) // nolint
+		return
+	}
+
+	fmt.Fprintf(GinkgoWriter, "CAPI Logs:\n%s\n", capiLogs)
+	fmt.Fprintf(GinkgoWriter, "CABPK Logs:\n%s\n", cabpkLogs)
+	fmt.Fprintf(GinkgoWriter, "CAPDO Logs:\n%s\n", capdoLogs)
+
+	kindcluster.Teardown()
+	os.RemoveAll(suiteTmpDir)
+})
+
+func buildCAPDOComponents(manifest *string) {
+	capdoManifests, err := exec.Command(*kustomizeBinary, "build", "../../config/default").Output() // nolint
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			fmt.Fprintf(GinkgoWriter, "Error: %s\n", string(exitError.Stderr))
+		}
+	}
+	Expect(err).NotTo(HaveOccurred())
+
+	// envsubst the credentials
+	b64credentials := base64.StdEncoding.EncodeToString([]byte(credentials))
+	os.Setenv("DO_B64ENCODED_CREDENTIALS", b64credentials)
+	manifestsContent := os.ExpandEnv(string(capdoManifests))
+
+	// write out the manifests
+	manifestFile := path.Join(suiteTmpDir, "infrastructure-components.yaml")
+	Expect(ioutil.WriteFile(manifestFile, []byte(manifestsContent), 0644)).To(Succeed())
+	*manifest = manifestFile
+}
+
+func buildCloudControllerManager(manifest *string) {
+	ccmManifests, err := ioutil.ReadFile("manifests/digitalocean-cloud-controller-manager.yaml")
+	Expect(err).NotTo(HaveOccurred())
+
+	// envsubst the credentials
+	manifestsContent := os.ExpandEnv(string(ccmManifests))
+	manifestFile := path.Join(suiteTmpDir, "digitalocean-cloud-controller-manager.yaml")
+	Expect(ioutil.WriteFile(manifestFile, []byte(manifestsContent), 0644)).To(Succeed())
+	*manifest = manifestFile
+}
+
+func retrieveLogs(namespace, deploymentName string) string {
+	deployment := &appsv1.Deployment{}
+	Expect(kindclient.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: deploymentName}, deployment)).To(Succeed())
+
+	pods := &corev1.PodList{}
+
+	selector, err := metav1.LabelSelectorAsMap(deployment.Spec.Selector)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(kindclient.List(context.TODO(), pods, crclient.InNamespace(namespace), crclient.MatchingLabels(selector))).To(Succeed())
+	Expect(pods.Items).NotTo(BeEmpty())
+
+	clientset, err := kubernetes.NewForConfig(kindcluster.RestConfig())
+	Expect(err).NotTo(HaveOccurred())
+
+	podLogs, err := clientset.CoreV1().Pods(namespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{Container: "manager"}).Stream()
+	Expect(err).NotTo(HaveOccurred())
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	Expect(err).NotTo(HaveOccurred())
+
+	return buf.String()
+}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os/exec"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TypeToKind returns the Kind without the package prefix. Pass in a pointer to a struct
+// This will panic if used incorrectly.
+func TypeToKind(i interface{}) string {
+	return reflect.ValueOf(i).Elem().Type().Name()
+}
+
+var (
+	pollTimeout  = 5 * time.Minute
+	pollInterval = 10 * time.Second
+)
+
+func WaitForClusterInfrastructureReady(client crclient.Client, namespace, name string) {
+	Eventually(func() (bool, error) {
+		cluster := &clusterv1.Cluster{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, cluster)
+		if err != nil {
+			return false, err
+		}
+
+		return cluster.Status.InfrastructureReady, nil
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func WaitForClusterControlplaneInitialized(client crclient.Client, namespace, name string) {
+	Eventually(func() (bool, error) {
+		cluster := &clusterv1.Cluster{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, cluster)
+		if err != nil {
+			return false, err
+		}
+
+		return cluster.Status.ControlPlaneInitialized, nil
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func WaitForMachineBootstrapReady(client crclient.Client, namespace, name string) {
+	Eventually(func() (bool, error) {
+		machine := &clusterv1.Machine{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, machine)
+		if err != nil {
+			return false, err
+		}
+
+		return machine.Status.BootstrapReady, nil
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func WaitForDOMachineRunning(client crclient.Client, namespace, name string) {
+	Eventually(func() (bool, error) {
+		domachine := &infrav1.DOMachine{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, domachine)
+		if err != nil {
+			return false, err
+		}
+
+		if *domachine.Status.InstanceStatus != infrav1.DOResourceStatusRunning {
+			return false, nil
+		}
+
+		return true, nil
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func WaitForDOMachineReady(client crclient.Client, namespace, name string) {
+	Eventually(func() (bool, error) {
+		domachine := &infrav1.DOMachine{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, domachine)
+		if err != nil {
+			return false, err
+		}
+
+		return domachine.Status.Ready, nil
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func WaitForMachineNodeRef(client crclient.Client, namespace, name string) {
+	Eventually(func() *corev1.ObjectReference {
+		machine := &clusterv1.Machine{}
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, machine)
+		if err != nil {
+			return nil
+		}
+
+		return machine.Status.NodeRef
+	}, pollTimeout, pollInterval).ShouldNot(BeNil())
+}
+
+func WaitForDeletion(client crclient.Client, obj runtime.Object, namespace, name string) {
+	Eventually(func() bool {
+		err := client.Get(context.TODO(), crclient.ObjectKey{Namespace: namespace, Name: name}, obj)
+		if err != nil {
+			return apierrors.IsNotFound(err)
+		}
+
+		return false
+	}, pollTimeout, pollInterval).Should(BeTrue())
+}
+
+func ApplyYaml(kubeconfig, manifest string) {
+	Eventually(func() error {
+		return exec.Command("kubectl", "create", "--kubeconfig", kubeconfig, "-f", manifest).Run()
+	}, pollTimeout, pollInterval).Should(Succeed())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add e2e test by creating and deleting a single controlplane and one worker cluster. both controlplane and worker created using machine api. 

So in this PR doesn't cover the machine deployment api maybe we can add machine deployment e2e test in the followup

Fixes #121

**Special notes for your reviewer**:

**Documentation**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```