### PR TITLE
[release-0.3] Use gcr.io/distroless/static:latest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -a -ldflags 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER nobody
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick #161 to release-0.3 branch.

**Release note**:
```release-note
NONE
```