### PR TITLE
Drop buildkit from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,7 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= Always
 
-# Enable docker buildkit as default for better build performance.
-DOCKER_BUILDKIT ?= 1
-export DOCKER_BUILDKIT
-
 KIND_CLUSTER_NAME ?= capdo
-
 
 ## --------------------------------------
 ##@ Help


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR drops buildkit from the Makefile because it might cause the issues we're seeing on Google Cloud/Cloud Build.

**Release note**:
```release-note
NONE
```