### PR TITLE
Drop buildkit from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,7 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= Always
 
-# Enable docker buildkit as default for better build performance.
-DOCKER_BUILDKIT ?= 1
-export DOCKER_BUILDKIT
-
 KIND_CLUSTER_NAME ?= capdo
-
 
 ## --------------------------------------
 ##@ Help


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker Buildkit doesn't work in Cloud Build at all, so this PR drops buildkit from the Makefile. With this PR, our image builds should be green again.

Here are some references for the problem we encountered:

* https://github.com/moby/moby/issues/39120
* https://github.com/moby/buildkit/issues/606#issuecomment-453959632

**Release note**:
```release-note
NONE
```