### PR TITLE
makefile: revert the buildKit but set to disable by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= Always
 
+# Docker buildkit disabled for now until we figure out how to fix when
+# building the image in the post stage
+DOCKER_BUILDKIT ?= 0
+export DOCKER_BUILDKIT
+
 KIND_CLUSTER_NAME ?= capdo
 
 ## --------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
This revert partially the PR #163 that removes the buildkit.

I think we can keep that variable but instead, we disable that for now, however, if any contributor wants to build that locally then they can set that.

Until we figure out why the post-stage fail to build when the buildkit is set.

/cc @xmudrii 
if you think this is not useful just close :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```