### PR TITLE
Change repository uri to match format for kustomize >= 3.5.5

### DIFF
--- a/examples/addons.yaml
+++ b/examples/addons.yaml
@@ -51,7 +51,7 @@ data:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -103,11 +103,11 @@ kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst >> "${MACHINEDEPLOY
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-kustomize build "github.com/kubernetes-sigs/cluster-api//config/default/?ref=v0.2.9" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+kustomize build "https://github.com/kubernetes-sigs/cluster-api/config/default/?ref=v0.2.9" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-kustomize build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm//config/default/?ref=v0.1.5" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+kustomize build "https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/config/default/?ref=v0.1.5" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate a single core components file.


### PR DESCRIPTION
… are needed to make generate.sh work.

**What this PR does / why we need it**:

This PR updates the uri's for two kustomize builds in the generate.sh script. Those uri's no longer work with kustomize > 3.5.5 because of a change in go-getter.

Also added a space in the crd files to have proper yaml formating.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

NA

**Special notes for your reviewer**:

NA

**Documentation**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```