### PR TITLE
Define default image tag to master

### DIFF
--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-do/cluster-api-do-controller
+      - image: gcr.io/k8s-staging-cluster-api-do/cluster-api-do-controller:master
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR to specify default manager image tag to `master` since the staging image is tagged with `master` not `latest` tag

**Special notes for your reviewer**:
/cc @xmudrii 

```release-note
NONE
```