### PR TITLE
manager: add both v1alpha2 and alpha3 scheme when start

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	"github.com/spf13/pflag"
-	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha3"
+	infrav1alpha2 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
+	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-digitalocean/controllers"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,8 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	_ = infrav1.AddToScheme(scheme)
+	_ = infrav1alpha2.AddToScheme(scheme)
+	_ = infrav1alpha3.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The others providers add both apis when start the manager, maybe we should do the same as well


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
manager: add both v1alpha2 and alpha3 scheme when start
```

/assign @prksu @xmudrii 