### PR TITLE
manager: add profiler port to expose pprof profiler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   exclude:
     - Using the variable on range scope `(tc)|(rt)|(tt)|(test)|(testcase)|(testCase)` in function literal
-    - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
 run:
   timeout: 6m
   skip-files:


### PR DESCRIPTION
**What this PR does / why we need it**:
continuing the changes to make more similar to the other providers, this adds the profiler port to expose to pprof profiler when needed.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
manager: add profiler port to expose pprof profiler
```

/assign @prksu @xmudrii @MorrisLaw 