### PR TITLE
fix metadata.yaml to use the correct release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 0
-  minor: 4
+  minor: 3
   contract: v1alpha3


### PR DESCRIPTION
**What this PR does / why we need it**:
We did not release version 0.4.x yet, we are on 0.3.0, this PR fix the metadata.yaml to point to the correct release that clusterctl can use.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xmudrii 