### PR TITLE
makefile: remove unused test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,6 @@ $(ARTIFACTS):
 test: generate lint ## Run tests
 	go test -v ./api/... ./controllers/... ./cloud/...
 
-.PHONY: test-integration
-test-integration: ## Run integration tests
-	go test -v -tags=integration ./test/integration/...
-
 .PHONY: test-e2e ## Run e2e tests using clusterctl
 test-e2e: $(GINKGO) $(KIND) $(KUSTOMIZE) e2e-image ## Run e2e tests
 	time $(GINKGO) -trace -progress -v -tags=e2e -focus=$(E2E_FOCUS) $(GINKGO_ARGS) ./test/e2e/... -- -e2e.config="$(E2E_CONF_FILE)" -e2e.artifacts-folder="$(ARTIFACTS)" $(E2E_ARGS)


### PR DESCRIPTION
**What this PR does / why we need it**:
makefile: remove unused test-integration

similar from: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/979

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```