### PR TITLE
Fix manager tolerations patch for provider-components

### DIFF
--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capdo-controller-manager
+  name: controller-manager
   namespace: capdo-system
 spec:
   template:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a mismatch on the kustomization patch for provider-components.

**Special notes for your reviewer**:
This could also be addressed by adjusting [the name on the referenced Deployment](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/7405bd11063b51c53ef8d34d8ece4d77f28fba3d/config/manager/manager.yaml#L5). Let me know if you prefer that.

```release-note
NONE
```