### PR TITLE
Match config namespace name

### DIFF
--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: system
+  name: capdo-system


### PR DESCRIPTION
**What this PR does / why we need it**:
The generated examples expect the namespace name to be "capdo-system". However, the name in config/default/namespace.yaml is set to `system`, and the `namespace` field from kustomize does not apply to Namespace resources.

The PR updates the namespace name accordingly.

**Special notes for your reviewer**:
An alternative approach would be to patch the Namespace resource explicitly via kustomize. I wasn't sure if the Namespace is meant to be copied verbatim from elsewhere frequently, in which case another patch would make sense. Let me know if that's desirable and I can update the PR accordingly.

**Release note**:
```release-note
NONE
```