### PR TITLE
Add missing clusterName to Machine

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -12,6 +12,7 @@ spec:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: ${CLUSTER_NAME}-controlplane-0
+  clusterName: ${CLUSTER_NAME}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DOMachine

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -6,6 +6,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     nodepool: nodepool-0
 spec:
+  clusterName: ${CLUSTER_NAME}
   replicas: 1
   selector:
     matchLabels:
@@ -23,6 +24,7 @@ spec:
           name: ${CLUSTER_NAME}-md-0
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
+      clusterName: ${CLUSTER_NAME}
       infrastructureRef:
         name: ${CLUSTER_NAME}-md-0
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the required `clusterName` field to `Machine*`.

**Special notes for your reviewer**:
I assume that the cluster name used to be covered by [this label](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/a0f34699d6a2a14712a6962bcd8f96d03168f8d8/examples/controlplane/controlplane.yaml#L7) in the past. I wasn't 100% sure if that label (and the neighboring `cluster.x-k8s.io/control-plane`) were now obsolete and can/should be deleted.
Please let me know if that's the case and update the PR accordingly.

**Release note**:
```release-note
NONE
```