### PR TITLE
janitor: add code to clean the DO account for capdo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,3 +507,7 @@ clean-examples: ## Remove all the temporary files generated in the examples fold
 	rm -rf examples/_out/
 	rm -f examples/core-components/*-components.yaml
 	rm -f examples/provider-components/provider-components-*.yaml
+
+.PHONY: do-janitor
+do-janitor: ## Cleanup old resources in the DO account
+	go run hack/do-janitor/do-janitor.go

--- a/scripts/ci-janitor.sh
+++ b/scripts/ci-janitor.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# usage: ci-janitor.sh
+#  This program runs the cleanup do account
+################################################################################
+
+set -o nounset
+set -o pipefail
+
+export PATH=${PWD}/hack/tools/bin:${PATH}
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# shellcheck source=../hack/ensure-go.sh
+source "${REPO_ROOT}/hack/ensure-go.sh"
+
+make do-janitor
+test_status="${?}"

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -87,6 +87,7 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 		By(fmt.Sprintf("Making sure there is no leftover running for %s", cluster.Name))
 		Expect(CleanDOResources(clusterName)).ShouldNot(HaveOccurred())
 	}
+
 	cancelWatches()
 	redactLogs()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add go code to clean up resources in the CAPDO DO Account that is older than 2 days to avoid account limits and spend $ for nothing.

I will add a periodic job in prow to run every day

/kind feature

/assign @MorrisLaw @prksu @xmudrii 

mention @timoreimann as well to be aware :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
janitor: add code to clean the DO account for capdo
```