### PR TITLE
Do not mark droplet create failures as terminal

### DIFF
--- a/controllers/domachine_controller.go
+++ b/controllers/domachine_controller.go
@@ -225,11 +225,10 @@ func (r *DOMachineReconciler) reconcile(ctx context.Context, machineScope *scope
 	if droplet == nil {
 		droplet, err = computesvc.CreateDroplet(machineScope)
 		if err != nil {
-			errs := errors.Errorf("Failed to create droplet instance for DOMachine %s/%s: %v", domachine.Namespace, domachine.Name, err)
-			machineScope.SetFailureReason(capierrors.CreateMachineError)
-			machineScope.SetFailureMessage(errs)
-			r.Recorder.Event(domachine, corev1.EventTypeWarning, "InstanceCreatingError", errs.Error())
-			return reconcile.Result{}, errs
+			err = errors.Errorf("Failed to create droplet instance for DOMachine %s/%s: %v", domachine.Namespace, domachine.Name, err)
+			r.Recorder.Event(domachine, corev1.EventTypeWarning, "InstanceCreatingError", err.Error())
+			machineScope.SetInstanceStatus(infrav1.DOResourceStatusErrored)
+			return reconcile.Result{}, err
 		}
 		r.Recorder.Eventf(domachine, corev1.EventTypeNormal, "InstanceCreated", "Created new droplet instance - %s", droplet.Name)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not mark droplet create failures as terminal.

This allows to address transient errors through automatic reconciles.

**Which issue(s) this PR fixes**:
Fixes #214

**Release note**:
```release-note
Do not mark droplet create failures as terminal to allow automatic remediation
```