### PR TITLE
Avoid panic on network error in DO API get requests

### DIFF
--- a/cloud/services/computes/droplets.go
+++ b/cloud/services/computes/droplets.go
@@ -44,16 +44,13 @@ func (s *Service) GetDroplet(id string) (*godo.Droplet, error) {
 
 	droplet, res, err := s.scope.Droplets.Get(s.ctx, dropletID)
 	if err != nil {
-		if res.StatusCode == http.StatusNotFound {
+		if res != nil && res.StatusCode == http.StatusNotFound {
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	if droplet != nil {
-		return droplet, nil
-	}
-	return nil, nil
+	return droplet, nil
 }
 
 // CreateDroplet create a droplet instance.

--- a/cloud/services/networking/loadbalancers.go
+++ b/cloud/services/networking/loadbalancers.go
@@ -31,7 +31,7 @@ func (s *Service) GetLoadBalancer(id string) (*godo.LoadBalancer, error) {
 
 	lb, res, err := s.scope.LoadBalancers.Get(s.ctx, id)
 	if err != nil {
-		if res.StatusCode == http.StatusNotFound {
+		if res != nil && res.StatusCode == http.StatusNotFound {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
When a digitalocean/godo request fails due to a network error, the returned `response` variable will be nil. Thus, we need to check for nil in case of a non-nil error before referencing `response` fields to avoid panicking.

As a drive-by improvement, we also simplify how we return the droplet variable when no error occurs.

**Release note**:
```release-note
Avoid panic on networking errors in get droplet requests
```