### PR TITLE
Remove finalizer when cloud resource is found absent

### DIFF
--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -166,6 +166,7 @@ func (r *DOClusterReconciler) reconcileDelete(ctx context.Context, clusterScope 
 	if loadbalancer == nil {
 		clusterScope.V(2).Info("Unable to locate load balancer")
 		r.Recorder.Eventf(docluster, corev1.EventTypeWarning, "NoLoadBalancerFound", "Unable to find matching load balancer")
+		controllerutil.RemoveFinalizer(docluster, infrav1.ClusterFinalizer)
 		return reconcile.Result{}, nil
 	}
 
@@ -173,7 +174,7 @@ func (r *DOClusterReconciler) reconcileDelete(ctx context.Context, clusterScope 
 		return reconcile.Result{}, errors.Wrapf(err, "error deleting load balancer for DOCluster %s/%s", docluster.Namespace, docluster.Name)
 	}
 
-	r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerDeleted", "Deleted a instance - %s", loadbalancer.Name)
+	r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerDeleted", "Deleted an LoadBalancer - %s", loadbalancer.Name)
 	// Cluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(docluster, infrav1.ClusterFinalizer)
 	return reconcile.Result{}, nil

--- a/controllers/domachine_controller.go
+++ b/controllers/domachine_controller.go
@@ -274,6 +274,7 @@ func (r *DOMachineReconciler) reconcileDelete(ctx context.Context, machineScope 
 	if droplet == nil {
 		clusterScope.V(2).Info("Unable to locate droplet instance")
 		r.Recorder.Eventf(domachine, corev1.EventTypeWarning, "NoInstanceFound", "Skip deleting")
+		controllerutil.RemoveFinalizer(domachine, infrav1.MachineFinalizer)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove finalizer when cloud resource is found absent.

This is to ensure that reconciles can complete even when cloud resources (droplets, LBs) cannot be referenced anymore.

**Which issue(s) this PR fixes**:
Fixes #218
Fixes #219

**Release note**:
```release-note
Remove finalizer when cloud resource is found absent
```