### PR TITLE
Let CCM reach API server through k8s svc to avoid bad TLS cert

### DIFF
--- a/examples/digitalocean-cloud-controller-manager.yaml
+++ b/examples/digitalocean-cloud-controller-manager.yaml
@@ -56,12 +56,6 @@ spec:
             cpu: 100m
             memory: 50Mi
         env:
-          - name: KUBERNETES_SERVICE_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: KUBERNETES_SERVICE_PORT
-            value: "6443"
           - name: DO_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, our example CCM uses the host IP address for the Kubernetes service host. This is problematic for cases where the original master node disappears (through, say, an initial upscale and subsequent downscale of the control plane) since the certificate won't be valid for that IP address anymore. Example output showing the problem:

```
E1215 23:06:20.726439       1 leaderelection.go:330] error retrieving resource lock kube-system/cloud-controller-manager: Get https://10.116.0.44:6443/api/v1/namespaces/kube-system/endpoints/cloud-controller-manager: x509: certificate is valid for 10.96.0.1, 67.205.137.20, 138.197.227.228, not 10.116.0.44
```

The solution is to not overwrite the Kubernetes service host environment variable and let CCM use the `kubernetes` service normally. This is guaranteed to work because API servers advertise their own IP address on startup, which then becomes part of the continuously reconciled `kubernetes` service's endpoint set.

**Release note**:
```release-note
NONE
```