### PR TITLE
Remove deprecate generate-examples Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,10 +254,6 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		output:rbac:dir=$(RBAC_ROOT) \
 		rbac:roleName=manager-role
 
-.PHONY: generate-examples
-generate-examples: clean-examples ## Generate examples configurations to run a cluster.
-	./examples/generate.sh
-
 ## --------------------------------------
 ##@ Docker
 ## --------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes deprecated generate-examples Makefile target (follow-up from #224).

**Release note**:
```release-note
NONE
```