### PR TITLE
Add Cluster UID in Loadbalancer name and Droplet target tag

### DIFF
--- a/api/v1alpha3/tags.go
+++ b/api/v1alpha3/tags.go
@@ -45,6 +45,12 @@ func ClusterNameRoleTag(clusterName, role string) string {
 	return fmt.Sprintf("%s:%s:%s", NameDigitalOceanProviderPrefix, clusterName, role)
 }
 
+// ClusterNameUIDRoleTag generates the tag with prefix `NameDigitalOceanProviderPrefix` and `RoleValue` as suffix
+// It will generated tag like `sigs-k8s-io:capdo:{clusterName}:{UID}:{role}`.
+func ClusterNameUIDRoleTag(clusterName, clusterUID, role string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", NameDigitalOceanProviderPrefix, clusterName, clusterUID, role)
+}
+
 // NameTagFromName returns DigitalOcean safe name tag from name.
 func NameTagFromName(name string) string {
 	return fmt.Sprintf("name:%s", DOSafeName(name))
@@ -54,6 +60,8 @@ func NameTagFromName(name string) string {
 type BuildTagParams struct {
 	// ClusterName is the cluster associated with the resource.
 	ClusterName string
+	// ClusterUID is the cluster uid from clusters.cluster.x-k8s.io uid
+	ClusterUID string
 	// Name is the name of the resource, it's applied as the tag "name" on DigitalOcean.
 	Name string
 	// Role is the role associated to the resource.
@@ -68,6 +76,7 @@ func BuildTags(params BuildTagParams) Tags {
 	var tags Tags
 	tags = append(tags, ClusterNameTag(params.ClusterName))
 	tags = append(tags, ClusterNameRoleTag(params.ClusterName, params.Role))
+	tags = append(tags, ClusterNameUIDRoleTag(params.ClusterName, params.ClusterUID, params.Role))
 	tags = append(tags, NameTagFromName(params.Name))
 
 	tags = append(tags, params.Additional...)

--- a/api/v1alpha3/tags_test.go
+++ b/api/v1alpha3/tags_test.go
@@ -35,11 +35,17 @@ func TestBuildTags(t *testing.T) {
 			args: args{
 				params: BuildTagParams{
 					ClusterName: "foo",
+					ClusterUID:  "155bd6ca-c6a9-45a8-8c9c-05e09b36bc42",
 					Name:        "bar",
 					Role:        APIServerRoleTagValue,
 				},
 			},
-			want: Tags{ClusterNameTag("foo"), ClusterNameRoleTag("foo", APIServerRoleTagValue), "name:" + "bar"},
+			want: Tags{
+				ClusterNameTag("foo"),
+				ClusterNameRoleTag("foo", APIServerRoleTagValue),
+				ClusterNameUIDRoleTag("foo", "155bd6ca-c6a9-45a8-8c9c-05e09b36bc42", APIServerRoleTagValue),
+				NameTagFromName("bar"),
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -123,6 +123,10 @@ func (s *ClusterScope) Namespace() string {
 	return s.Cluster.GetNamespace()
 }
 
+func (s *ClusterScope) UID() string {
+	return string(s.Cluster.UID)
+}
+
 // Region returns the cluster region.
 func (s *ClusterScope) Region() string {
 	return s.DOCluster.Spec.Region

--- a/cloud/services/computes/droplets.go
+++ b/cloud/services/computes/droplets.go
@@ -112,6 +112,7 @@ func (s *Service) CreateDroplet(scope *scope.MachineScope) (*godo.Droplet, error
 
 	request.Tags = infrav1.BuildTags(infrav1.BuildTagParams{
 		ClusterName: clusterName,
+		ClusterUID:  s.scope.UID(),
 		Name:        instanceName,
 		Role:        scope.Role(),
 		Additional:  scope.AdditionalTags(),

--- a/cloud/services/networking/loadbalancers.go
+++ b/cloud/services/networking/loadbalancers.go
@@ -42,7 +42,7 @@ func (s *Service) GetLoadBalancer(id string) (*godo.LoadBalancer, error) {
 
 func (s *Service) CreateLoadBalancer(spec *infrav1.DOLoadBalancer) (*godo.LoadBalancer, error) {
 	clusterName := infrav1.DOSafeName(s.scope.Name())
-	name := clusterName + "-" + infrav1.APIServerRoleTagValue
+	name := clusterName + "-" + infrav1.APIServerRoleTagValue + "-" + s.scope.UID()
 	request := &godo.LoadBalancerRequest{
 		Name:      name,
 		Algorithm: spec.Algorithm,
@@ -63,7 +63,7 @@ func (s *Service) CreateLoadBalancer(spec *infrav1.DOLoadBalancer) (*godo.LoadBa
 			UnhealthyThreshold:     spec.HealthCheck.UnhealthyThreshold,
 			HealthyThreshold:       spec.HealthCheck.HealthyThreshold,
 		},
-		Tag:     infrav1.ClusterNameRoleTag(clusterName, infrav1.APIServerRoleTagValue),
+		Tag:     infrav1.ClusterNameUIDRoleTag(clusterName, s.scope.UID(), infrav1.APIServerRoleTagValue),
 		VPCUUID: s.scope.VPC().VPCUUID,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Cluster UID in Loadbalancer name and adds an additional tag that contains Cluster UID for droplet target tag to allow creating two or more clusters with the same name but different namespace in the single management cluster.

**Which issue(s) this PR fixes**:
Fixes #217

**Special notes for your reviewer**:
/cc @timoreimann 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add Cluster UID in Loadbalancer name and Droplet target tag
```