### PR TITLE
Omitempty ControlPlaneDNS

### DIFF
--- a/api/v1alpha3/docluster_types.go
+++ b/api/v1alpha3/docluster_types.go
@@ -44,7 +44,7 @@ type DOClusterSpec struct {
 	// ControlPlaneDNS is a managed DNS name that points to the load-balancer
 	// IP used for the ControlPlaneEndpoint.
 	// +optional
-	ControlPlaneDNS *DOControlPlaneDNS `json:"controlPlaneDNS"`
+	ControlPlaneDNS *DOControlPlaneDNS `json:"controlPlaneDNS,omitempty"`
 }
 
 // DOClusterStatus defines the observed state of DOCluster.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `omitempty` json tag to `ControlPlaneDNS` field. It's fine since `ControlPlaneDNS` is optional.

**Special notes for your reviewer**:

cc @gottwald 

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```