### PR TITLE
Update klog dependency to v2

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -24,7 +24,7 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha3"
 
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2/klogr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/patch"

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"

--- a/controllers/domachine_controller_unit_test.go
+++ b/controllers/domachine_controller_unit_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2/klogr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,8 +28,8 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	k8s.io/api v0.17.14
 	k8s.io/apimachinery v0.17.14
 	k8s.io/client-go v0.17.14
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.0.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/cluster-api v0.3.14
 	sigs.k8s.io/controller-runtime v0.5.14

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	infrav1alpha2 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha2"
 	infrav1alpha3 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-digitalocean/controllers"


### PR DESCRIPTION
**What this PR does / why we need it**:

The klog v1 dependency used is quite old now, and the k/k repo has
switched to more recent v2 versions for quite some time now.

This updates klog usage to use the v2 package version.

**Special notes for your reviewer**:

This is part of an overall effort along with updating the k-sigs/cluster-api repo here:

https://github.com/kubernetes-sigs/cluster-api/pull/4284

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```