### PR TITLE
Move dns propagnation helpers to own packages

### DIFF
--- a/api/v1alpha3/docluster_types.go
+++ b/api/v1alpha3/docluster_types.go
@@ -62,10 +62,13 @@ type DOClusterStatus struct {
 }
 
 type DOControlPlaneDNS struct {
-	// Domain is the DO domain that this record should live in.
-	// It must be pre-existing in your DO account.
+	// Domain is the DO domain that this record should live in. It must be pre-existing in your DO account.
+	// The format must be a string that conforms to the definition of a subdomain in DNS (RFC 1123)
+	// +kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 	Domain string `json:"domain"`
 	// Name is the DNS short name of the record (non-FQDN)
+	// The format must consist of alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
+	// +kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
 	Name string `json:"name"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
@@ -189,10 +189,16 @@ spec:
                 properties:
                   domain:
                     description: Domain is the DO domain that this record should live
-                      in. It must be pre-existing in your DO account.
+                      in. It must be pre-existing in your DO account. The format must
+                      be a string that conforms to the definition of a subdomain in
+                      DNS (RFC 1123)
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   name:
                     description: Name is the DNS short name of the record (non-FQDN)
+                      The format must consist of alphanumeric characters, '-' or '.',
+                      and must start and end with an alphanumeric character
+                    pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                     type: string
                 required:
                 - domain

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -19,16 +19,15 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-digitalocean/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-digitalocean/cloud/services/networking"
+	dnsutil "sigs.k8s.io/cluster-api-provider-digitalocean/util/dns"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +46,6 @@ type DOClusterReconciler struct {
 	client.Client
 	Log      logr.Logger
 	Recorder record.EventRecorder
-	DNS      networking.DNSQuerier
 }
 
 func (r *DOClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -146,24 +144,27 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 
 	r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerReady", "LoadBalancer got an IP Address - %s", loadbalancer.IP)
 
-	var cpEndpointHost = loadbalancer.IP
+	var controlPlaneEndpoint = loadbalancer.IP
 	if docluster.Spec.ControlPlaneDNS != nil {
 		if err := checkDNSNameAllowed(docluster.Spec.ControlPlaneDNS.Name); err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed to manage DNS Name %q is not allowed as Name", docluster.Spec.ControlPlaneDNS.Name)
 		}
+
 		clusterScope.Info("Verifying LB DNS Record")
 		// ensure DNS record is created and use it as control plane endpoint
 		recordSpec := docluster.Spec.ControlPlaneDNS
-		cpEndpointHost = fmt.Sprintf("%s.%s", recordSpec.Name, recordSpec.Domain)
+		controlPlaneEndpoint = fmt.Sprintf("%s.%s", recordSpec.Name, recordSpec.Domain)
 		dRecord, err := networkingsvc.GetDomainRecord(
 			recordSpec.Domain,
 			recordSpec.Name,
 			"A",
 		)
+
 		if err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed verify DNS record for LB Name %s.%s",
 				recordSpec.Name, recordSpec.Domain)
 		}
+
 		if dRecord == nil || dRecord.Data != loadbalancer.IP {
 			clusterScope.Info("Ensuring LB DNS Record is in place")
 			clusterScope.SetControlPlaneDNSRecordReady(false)
@@ -176,6 +177,7 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 				return reconcile.Result{}, errors.Wrap(err, "failed to reconcile LB DNS record")
 			}
 		}
+
 		// If the record has never been ready we need to check whether it has
 		// been propagated or not. Updating the record in the DNS API does not
 		// mean it is already advertised at the DNS server. If the DNS is slower
@@ -185,23 +187,26 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 		// propagation check works around the DNS cache problem by directly
 		// making DNS queries and not going through system resolvers.
 		if !clusterScope.DOCluster.Status.ControlPlaneDNSRecordReady {
-			propagated, err := r.dnsIsPropagated(recordSpec.Name, recordSpec.Domain, loadbalancer.IP)
+			propagated, err := dnsutil.CheckDNSPropagated(dnsutil.ToFQDN(recordSpec.Name, recordSpec.Domain), loadbalancer.IP)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to check DNS propagation")
 			}
+
 			if !propagated {
 				clusterScope.Info("Waiting for DNS record to be propagated")
 				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 			}
+
 			clusterScope.Info("DNS record is propagated - set DOCluster ControlPlaneDNSRecordReady status to ready")
 			clusterScope.SetControlPlaneDNSRecordReady(true)
 		}
+
 		clusterScope.Info("LB DNS Record is already ready")
 		r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "DomainRecordReady", "DNS Record '%s.%s' with IP '%s'", recordSpec.Name, recordSpec.Domain, loadbalancer.IP)
 	}
 
 	clusterScope.SetControlPlaneEndpoint(clusterv1.APIEndpoint{
-		Host: cpEndpointHost,
+		Host: controlPlaneEndpoint,
 		Port: int32(apiServerLoadbalancer.Port),
 	})
 
@@ -219,60 +224,6 @@ func checkDNSNameAllowed(name string) error {
 		return errors.New("* is not allowed")
 	}
 	return nil
-}
-
-func (r *DOClusterReconciler) dnsIsPropagated(name, domain, ip string) (bool, error) {
-	fqdn := fmt.Sprintf("%s.%s", name, domain)
-	if !strings.HasSuffix(fqdn, ".") {
-		fqdn = fqdn + "."
-	}
-	authNS, err := r.getAuthoritativeServer(fqdn)
-	if err != nil {
-		return false, err
-	}
-	m := new(dns.Msg)
-	m.SetQuestion(fqdn, dns.TypeA)
-	resp, err := r.DNS.Query([]string{authNS}, m)
-	if err != nil {
-		return false, err
-	}
-	for _, ans := range resp.Answer {
-		switch a := ans.(type) {
-		case *dns.A:
-			if a.A.String() == ip {
-				return true, nil
-			}
-		default:
-			continue
-		}
-	}
-	return false, nil
-}
-
-func (r *DOClusterReconciler) getAuthoritativeServer(fqdn string) (string, error) {
-	m := new(dns.Msg)
-	m.SetQuestion(fqdn, dns.TypeSOA)
-	m.MsgHdr.RecursionDesired = true
-	resp, err := r.DNS.LocalQuery(m)
-	if err != nil {
-		return "", err
-	}
-	if len(resp.Ns) < 1 {
-		return "", fmt.Errorf("didn't get DNS authority section")
-	}
-	var authNS string
-	for _, rr := range resp.Ns {
-		soa, ok := rr.(*dns.SOA)
-		if !ok {
-			continue
-		}
-		authNS = soa.Ns
-		break
-	}
-	if authNS == "" {
-		return "", fmt.Errorf("didn't find authority NS")
-	}
-	return authNS, nil
 }
 
 func (r *DOClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -146,10 +146,6 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 
 	var controlPlaneEndpoint = loadbalancer.IP
 	if docluster.Spec.ControlPlaneDNS != nil {
-		if err := checkDNSNameAllowed(docluster.Spec.ControlPlaneDNS.Name); err != nil {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to manage DNS Name %q is not allowed as Name", docluster.Spec.ControlPlaneDNS.Name)
-		}
-
 		clusterScope.Info("Verifying LB DNS Record")
 		// ensure DNS record is created and use it as control plane endpoint
 		recordSpec := docluster.Spec.ControlPlaneDNS
@@ -214,16 +210,6 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 	clusterScope.SetReady()
 	r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "DOClusterReady", "DOCluster %s - has ready status", clusterScope.Name())
 	return reconcile.Result{}, nil
-}
-
-func checkDNSNameAllowed(name string) error {
-	switch name {
-	case "@":
-		return errors.New("@ is not allowed")
-	case "*":
-		return errors.New("* is not allowed")
-	}
-	return nil
 }
 
 func (r *DOClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {

--- a/util/dns/dns.go
+++ b/util/dns/dns.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+	"sigs.k8s.io/cluster-api-provider-digitalocean/util/dns/resolver"
+)
+
+var (
+	syncOnce        sync.Once
+	defaultResolver resolver.DNSResolver
+)
+
+func init() {
+	defaultResolver = resolver.NewFakeDNSResolver([]*dns.Msg{})
+}
+
+func InitFromDNSResolver(resolver resolver.DNSResolver) {
+	syncOnce.Do(func() {
+		defaultResolver = resolver
+	})
+}
+
+func ToFQDN(name, domain string) string {
+	fqdn := fmt.Sprintf("%s.%s", name, domain)
+	if !strings.HasSuffix(fqdn, ".") {
+		fqdn = fqdn + "."
+	}
+
+	return fqdn
+}
+
+func CheckDNSPropagated(fqdn, ip string) (bool, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(fqdn, dns.TypeA)
+
+	authNS, err := LookupAuthoritativeServer(fqdn)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := defaultResolver.Query([]string{authNS}, m)
+	if err != nil {
+		return false, err
+	}
+
+	for _, ans := range resp.Answer {
+		switch a := ans.(type) {
+		case *dns.A:
+			if a.A.String() == ip {
+				return true, nil
+			}
+		default:
+			continue
+		}
+	}
+
+	return false, nil
+}
+
+func LookupAuthoritativeServer(fqdn string) (string, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(fqdn, dns.TypeSOA)
+	m.MsgHdr.RecursionDesired = true
+	resp, err := defaultResolver.LocalQuery(m)
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.Ns) < 1 {
+		return "", fmt.Errorf("didn't get DNS authority section")
+	}
+
+	var authNS string
+	for _, rr := range resp.Ns {
+		soa, ok := rr.(*dns.SOA)
+		if !ok {
+			continue
+		}
+		authNS = soa.Ns
+		break
+	}
+
+	if authNS == "" {
+		return "", fmt.Errorf("didn't find authority NS")
+	}
+
+	return authNS, nil
+}

--- a/util/dns/resolver/faker.go
+++ b/util/dns/resolver/faker.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"github.com/miekg/dns"
+)
+
+type FakeDNSResolver struct {
+	expectedMsg []*dns.Msg
+	c           int
+}
+
+func NewFakeDNSResolver(expectedMsg []*dns.Msg) *FakeDNSResolver {
+	return &FakeDNSResolver{
+		expectedMsg: expectedMsg,
+	}
+}
+
+func (f *FakeDNSResolver) Query(servers []string, msg *dns.Msg) (*dns.Msg, error) {
+	if len(f.expectedMsg) <= f.c {
+		return msg, nil
+	}
+
+	r := f.expectedMsg[f.c]
+	f.c++
+	return r, nil
+}
+
+func (f *FakeDNSResolver) LocalQuery(msg *dns.Msg) (*dns.Msg, error) {
+	return f.Query(nil, msg)
+}

--- a/util/dns/resolver/resolver.go
+++ b/util/dns/resolver/resolver.go
@@ -14,48 +14,52 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networking
+package resolver
 
 import (
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 )
 
-type DNSQuerier interface {
+type DNSResolver interface {
 	Query(servers []string, msg *dns.Msg) (*dns.Msg, error)
 	LocalQuery(msg *dns.Msg) (*dns.Msg, error)
 }
 
-type DNSResolver struct {
+type resolver struct {
 	config *dns.ClientConfig
 	client *dns.Client
 }
 
-func NewDNSResolver() (*DNSResolver, error) {
+func NewDNSResolver() (DNSResolver, error) {
 	dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get DNS config")
 	}
-	sq := &DNSResolver{
+
+	sq := &resolver{
 		config: dnsConfig,
 		client: new(dns.Client),
 	}
+
 	return sq, nil
 }
 
-func (dr *DNSResolver) Query(servers []string, msg *dns.Msg) (*dns.Msg, error) {
+func (r *resolver) Query(servers []string, msg *dns.Msg) (*dns.Msg, error) {
 	for _, server := range servers {
-		r, _, err := dr.client.Exchange(msg, server+":"+dr.config.Port)
+		r, _, err := r.client.Exchange(msg, server+":"+r.config.Port)
 		if err != nil {
 			return nil, err
 		}
+
 		if r == nil || r.Rcode == dns.RcodeNameError || r.Rcode == dns.RcodeSuccess {
 			return r, err
 		}
 	}
+
 	return nil, errors.New("No name server to answer the question")
 }
 
-func (dr *DNSResolver) LocalQuery(msg *dns.Msg) (*dns.Msg, error) {
-	return dr.Query(dr.config.Servers, msg)
+func (r *resolver) LocalQuery(msg *dns.Msg) (*dns.Msg, error) {
+	return r.Query(r.config.Servers, msg)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR move DNS propagation helpers to own packages since `cloud` directory is devoted to related cloud provider stuff

**Special notes for your reviewer**:
/cc @gottwald 
/assign @timoreimann 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
None
```