### PR TITLE
Minimize API requests by skipping to check a given image ID

### DIFF
--- a/cloud/services/computes/droplets.go
+++ b/cloud/services/computes/droplets.go
@@ -66,7 +66,7 @@ func (s *Service) CreateDroplet(scope *scope.MachineScope) (*godo.Droplet, error
 	clusterName := infrav1.DOSafeName(s.scope.Name())
 	instanceName := infrav1.DOSafeName(scope.Name())
 
-	image, err := s.GetImage(scope.DOMachine.Spec.Image)
+	imageID, err := s.GetImageID(scope.DOMachine.Spec.Image)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed getting image")
 	}
@@ -102,7 +102,7 @@ func (s *Service) CreateDroplet(scope *scope.MachineScope) (*godo.Droplet, error
 		Size:    scope.DOMachine.Spec.Size,
 		SSHKeys: sshkeys,
 		Image: godo.DropletCreateImage{
-			ID: image.ID,
+			ID: imageID,
 		},
 		UserData:          bootstrapData,
 		PrivateNetworking: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Save on API requests and stop querying for the image ID from the DO API if the numeric ID is already given: a failure to reference the image would show up during the droplet create request and lead to the same backoff that we run into today.

**Special notes for your reviewer**:
Also refactor the code and improve error messages slightly as a drive-by change.

**Release note**:
```release-note
NONE
```