### PR TITLE
Update janitor job to remove volumes used by kops e2e jobs

### DIFF
--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -85,6 +85,25 @@ func main() {
 		}
 	}
 
+	volumes, err := volumeList(ctx, client)
+	if err != nil {
+		log.Fatalf("failed to list volumes: %+v", err.Error())
+	}
+
+	for _, volume := range volumes {
+		hours := time.Since(volume.CreatedAt).Hours()
+		if hours >= timeToCleanInHours && len(volume.DropletIDs) < 1 {
+			log.Printf("%s is older than %d hours will terminate\n", volume.Name, timeToCleanInHours)
+			_, err := client.Storage.DeleteVolume(ctx, volume.ID)
+			if err != nil {
+				log.Printf("failed to delete volume %s: %+v\n", volume.Name, err.Error())
+				continue
+			}
+
+			log.Printf("volume %s terminated\n", volume.Name)
+		}
+	}
+
 	log.Println("Completed DO Janitor")
 	os.Exit(0)
 }
@@ -139,6 +158,34 @@ func lbList(ctx context.Context, client *godo.Client) ([]godo.LoadBalancer, erro
 		}
 
 		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func volumeList(ctx context.Context, client *godo.Client) ([]godo.Volume, error) {
+	list := []godo.Volume{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListVolumeParams{}
+	for {
+		volumes, resp, err := client.Storage.ListVolumes(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		list = append(list, volumes...)
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opt.ListOptions.Page = page + 1
 	}
 
 	return list, nil


### PR DESCRIPTION
**What this PR does / why we need it**: We are currently using the same DO account for running KOPS e2e tests. Please see the prow job status [here](https://prow.k8s.io/?job=e2e-kops-do-calico). and the kops test grid dashboard [here ](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#e2e-kops-do-calico)
Per discussion with @timoreimann we thought of adding a cleanup job just in case some of the old resources weren't cleaned up . Since we saw this code was already generically handling cleaning up droplets and load balancer resources, I am updating this to also cleanup volumes that KOPS uses to store etcd data.

**Special notes for your reviewer**:  Tested this locally, and it seems to work as expected. Please see the logs for reference -
```
go run hack/do-janitor/do-janitor.go
2021/06/15 20:18:21 Starting DO Janitor
2021/06/15 20:18:25 kops-etcd-1-etcd-events-dev5-techthreads-co-in is older than 12 hours will terminate
2021/06/15 20:18:25 volume kops-etcd-1-etcd-events-dev5-techthreads-co-in terminated
2021/06/15 20:18:25 kops-etcd-1-etcd-main-dev5-techthreads-co-in is older than 12 hours will terminate
2021/06/15 20:18:27 volume kops-etcd-1-etcd-main-dev5-techthreads-co-in terminated
2021/06/15 20:18:27 Completed DO Janitor
```

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**: 
NONE