### PR TITLE
Fix controlPlaneEndpoint validation error message (release-1.0)

### DIFF
--- a/api/v1beta1/docluster_webhook.go
+++ b/api/v1beta1/docluster_webhook.go
@@ -69,7 +69,7 @@ func (r *DOCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if !reflect.DeepEqual(clusterv1.APIEndpoint{}, oldDOCluster.Spec.ControlPlaneEndpoint) && !reflect.DeepEqual(r.Spec.ControlPlaneEndpoint, oldDOCluster.Spec.ControlPlaneEndpoint) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneEndpoint"), r.Spec.Region, "field is immutable"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneEndpoint"), r.Spec.ControlPlaneEndpoint, "field is immutable"))
 	}
 
 	if len(allErrs) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the validation error message around `controlPlaneEndpoint` that incorrectly showed the content of the region due to a copy-paste mistake.

Cherry-pick from #287.

```release-note
Fix controlPlaneEndpoint validation error message
```

/assign @cpanato 