### PR TITLE
add lb uuid to docluster spec

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -114,6 +114,9 @@ type DOLoadBalancer struct {
 	// An object specifying health check settings for the Load Balancer. If omitted, default values will be provided.
 	// +optional
 	HealthCheck DOLoadBalancerHealthCheck `json:"healthCheck,omitempty"`
+	// The DO load balancer UUID. If omitted, a new load balancer will be created.
+	// +optional
+	ResourceID string `json:"resourceId,omitempty"`
 }
 
 // DOVPC define the DigitalOcean VPC configuration.

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -420,6 +420,7 @@ func autoConvert_v1alpha3_DOLoadBalancer_To_v1beta1_DOLoadBalancer(in *DOLoadBal
 	if err := Convert_v1alpha3_DOLoadBalancerHealthCheck_To_v1beta1_DOLoadBalancerHealthCheck(&in.HealthCheck, &out.HealthCheck, s); err != nil {
 		return err
 	}
+	out.ResourceID = in.ResourceID
 	return nil
 }
 
@@ -434,6 +435,7 @@ func autoConvert_v1beta1_DOLoadBalancer_To_v1alpha3_DOLoadBalancer(in *v1beta1.D
 	if err := Convert_v1beta1_DOLoadBalancerHealthCheck_To_v1alpha3_DOLoadBalancerHealthCheck(&in.HealthCheck, &out.HealthCheck, s); err != nil {
 		return err
 	}
+	out.ResourceID = in.ResourceID
 	return nil
 }
 

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -126,6 +126,9 @@ type DOLoadBalancer struct {
 	// An object specifying health check settings for the Load Balancer. If omitted, default values will be provided.
 	// +optional
 	HealthCheck DOLoadBalancerHealthCheck `json:"healthCheck,omitempty"`
+	// The DO load balancer UUID. If omitted, a new load balancer will be created.
+	// +optional
+	ResourceID string `json:"resourceId,omitempty"`
 }
 
 // DOVPC define the DigitalOcean VPC configuration.

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -420,6 +420,7 @@ func autoConvert_v1alpha4_DOLoadBalancer_To_v1beta1_DOLoadBalancer(in *DOLoadBal
 	if err := Convert_v1alpha4_DOLoadBalancerHealthCheck_To_v1beta1_DOLoadBalancerHealthCheck(&in.HealthCheck, &out.HealthCheck, s); err != nil {
 		return err
 	}
+	out.ResourceID = in.ResourceID
 	return nil
 }
 
@@ -434,6 +435,7 @@ func autoConvert_v1beta1_DOLoadBalancer_To_v1alpha4_DOLoadBalancer(in *v1beta1.D
 	if err := Convert_v1beta1_DOLoadBalancerHealthCheck_To_v1alpha4_DOLoadBalancerHealthCheck(&in.HealthCheck, &out.HealthCheck, s); err != nil {
 		return err
 	}
+	out.ResourceID = in.ResourceID
 	return nil
 }
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -126,6 +126,9 @@ type DOLoadBalancer struct {
 	// An object specifying health check settings for the Load Balancer. If omitted, default values will be provided.
 	// +optional
 	HealthCheck DOLoadBalancerHealthCheck `json:"healthCheck,omitempty"`
+	// The DO load balancer uuid. If omitted, a new load balancer will be created.
+	// +optional
+	ResourceId string `json:"resourceId,omitempty"`
 }
 
 // DOVPC define the DigitalOcean VPC configuration.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -126,9 +126,9 @@ type DOLoadBalancer struct {
 	// An object specifying health check settings for the Load Balancer. If omitted, default values will be provided.
 	// +optional
 	HealthCheck DOLoadBalancerHealthCheck `json:"healthCheck,omitempty"`
-	// The DO load balancer uuid. If omitted, a new load balancer will be created.
+	// The DO load balancer UUID. If omitted, a new load balancer will be created.
 	// +optional
-	ResourceId string `json:"resourceId,omitempty"`
+	ResourceID string `json:"resourceId,omitempty"`
 }
 
 // DOVPC define the DigitalOcean VPC configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
@@ -501,7 +501,7 @@ spec:
                         minimum: 1
                         type: integer
                       resourceId:
-                        description: The DO load balancer uuid. If omitted, a new
+                        description: The DO load balancer UUID. If omitted, a new
                           load balancer will be created.
                         type: string
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
@@ -146,6 +146,10 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      resourceId:
+                        description: The DO load balancer UUID. If omitted, a new
+                          load balancer will be created.
+                        type: string
                     type: object
                   vpc:
                     description: VPC defines the VPC configuration.
@@ -323,6 +327,10 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      resourceId:
+                        description: The DO load balancer UUID. If omitted, a new
+                          load balancer will be created.
+                        type: string
                     type: object
                   vpc:
                     description: VPC defines the VPC configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclusters.yaml
@@ -500,6 +500,10 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      resourceId:
+                        description: The DO load balancer uuid. If omitted, a new
+                          load balancer will be created.
+                        type: string
                     type: object
                   vpc:
                     description: VPC defines the VPC configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclustertemplates.yaml
@@ -147,6 +147,10 @@ spec:
                                 maximum: 65535
                                 minimum: 1
                                 type: integer
+                              resourceId:
+                                description: The DO load balancer uuid. If omitted,
+                                  a new load balancer will be created.
+                                type: string
                             type: object
                           vpc:
                             description: VPC defines the VPC configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_doclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_doclustertemplates.yaml
@@ -148,7 +148,7 @@ spec:
                                 minimum: 1
                                 type: integer
                               resourceId:
-                                description: The DO load balancer uuid. If omitted,
+                                description: The DO load balancer UUID. If omitted,
                                   a new load balancer will be created.
                                 type: string
                             type: object

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -133,7 +133,13 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 	apiServerLoadbalancer.ApplyDefault()
 
 	apiServerLoadbalancerRef := clusterScope.APIServerLoadbalancersRef()
-	loadbalancer, err := networkingsvc.GetLoadBalancer(apiServerLoadbalancerRef.ResourceID)
+	lbUUID := apiServerLoadbalancerRef.ResourceID
+
+	if apiServerLoadbalancer.ResourceId != "" {
+		lbUUID = apiServerLoadbalancer.ResourceId
+	}
+
+	loadbalancer, err := networkingsvc.GetLoadBalancer(lbUUID)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -148,6 +154,7 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 
 	apiServerLoadbalancerRef.ResourceID = loadbalancer.ID
 	apiServerLoadbalancerRef.ResourceStatus = infrav1.DOResourceStatus(loadbalancer.Status)
+	apiServerLoadbalancer.ResourceId = loadbalancer.ID
 
 	if apiServerLoadbalancerRef.ResourceStatus != infrav1.DOResourceStatusRunning && loadbalancer.IP == "" {
 		clusterScope.Info("Waiting on API server Global IP Address")

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -135,8 +135,8 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 	apiServerLoadbalancerRef := clusterScope.APIServerLoadbalancersRef()
 	lbUUID := apiServerLoadbalancerRef.ResourceID
 
-	if apiServerLoadbalancer.ResourceId != "" {
-		lbUUID = apiServerLoadbalancer.ResourceId
+	if apiServerLoadbalancer.ResourceID != "" {
+		lbUUID = apiServerLoadbalancer.ResourceID
 	}
 
 	loadbalancer, err := networkingsvc.GetLoadBalancer(lbUUID)
@@ -154,7 +154,7 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 
 	apiServerLoadbalancerRef.ResourceID = loadbalancer.ID
 	apiServerLoadbalancerRef.ResourceStatus = infrav1.DOResourceStatus(loadbalancer.Status)
-	apiServerLoadbalancer.ResourceId = loadbalancer.ID
+	apiServerLoadbalancer.ResourceID = loadbalancer.ID
 
 	if apiServerLoadbalancerRef.ResourceStatus != infrav1.DOResourceStatusRunning && loadbalancer.IP == "" {
 		clusterScope.Info("Waiting on API server Global IP Address")


### PR DESCRIPTION
**What this PR does / why we need it**:

DO LB uuid is currently stored in status. Upon restore, we lose this information and capdo creates a new LB instead of re-using the existing LB. This PR adds the lb uuid in the spec. And updates the docluster controller to prefer the spec uuid over status if present. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #290 

**Special notes for your reviewer**:
- I only made this change for v1beta1. And ran `make generate`, got a few warnings like:
```
E1228 13:28:36.045121   30566 conversion.go:755] Warning: could not find nor generate a final Conversion function for sigs.k8s.io/cluster-api-provider-digitalocean/api/v1beta1.DOLoadBalancer -> github.com/kubernetes-sigs/cluster-api-provider-digitalocean/api/v1alpha4.DOLoadBalancer
```

- I am yet to test this. The setup we use internally in DO still uses v1alpha4, which makes it difficult for me to test this. 



**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
Allow specifying an existing DO LB in docluster spec
```