### PR TITLE
update to use the current minikube drivers link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,7 +184,7 @@ $ kubectl delete cluster capdo-quickstart
 [kind]: https://github.com/kubernetes-sigs/kind#installation-and-usage
 [doctl]: https://github.com/digitalocean/doctl#installing-doctl
 [Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
-[Minikube Driver]: https://github.com/kubernetes/minikube/blob/master/docs/drivers.md
+[Minikube Driver]: https://minikube.sigs.k8s.io/docs/drivers
 [Packer]: https://www.packer.io/intro/getting-started/install.html
 [Ansible]: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 [DigitalOcean]: https://cloud.digitalocean.com/


### PR DESCRIPTION
**What this PR does / why we need it**:
noticed a link was broken in the `getting-started` guide, this PR points that link to the correct `drivers list` page

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```