### PR TITLE
owners: add missing emeritus members and sync capi owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,6 @@ approvers:
 reviewers:
   - cluster-api-maintainers
   - cluster-api-do-maintainers
+
+emeritus_approvers:
+  - xmudrii

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,19 +2,22 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
+    - justinsb
     - neolit123
-    - justinsb
     - timothysc
+
   cluster-api-admins:
-    - justinsb
-    - detiber
-    - davidewatson
+    - CecileRobertMichon
     - vincepri
+
   cluster-api-maintainers:
-    - justinsb
-    - detiber
+    - CecileRobertMichon
+    - enxebre
+    - fabriziopandini
+    - sbueringer
     - vincepri
-    - chuckha
+
   cluster-api-do-maintainers:
     - cpanato
     - MorrisLaw


### PR DESCRIPTION
**What this PR does / why we need it**:

- owners: update/sync capi owners
- owners: add missing emeritus members

emeritus was missing in the owners file

/assign @timoreimann @MorrisLaw @prksu 
cc @xmudrii @andrewsykim @fabriziopandini 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```