### PR TITLE
clean up ssh keys when cleaning up e2e test resources

### DIFF
--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -110,22 +110,18 @@ func main() {
 		log.Fatalf("failed to list keys: %+v", err.Error())
 	}
 
+	capdoStr := "capdo" // using this for repeated comparisons in the loop below
 	for _, key := range keys {
-		// we only care to delete keys that start with "capdo"
-		match, err := regexp.MatchString(`^capdo`, key.Name)
-		if match != true {
-			continue
+		// we only care to cleanup keys that start with "capdo"
+		if len(key.Name) >= len(capdoStr) && key.Name[0:len(capdoStr)] == capdoStr {
+			log.Printf("%s contains capdo at the start of it's name so it's safe to terminate\n", key.Name)
+			_, err := client.Keys.DeleteByID(ctx, key.ID)
+			if err != nil {
+				log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
+				continue
+			}
+			log.Printf("key %s terminated\n", key.Name)
 		}
-		if err != nil {
-			log.Fatalf("failed to match against key name %s: %+v\n", key.Name, err.Error())
-		}
-		_, err = client.Keys.DeleteByID(ctx, key.ID)
-		if err != nil {
-			log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
-			continue
-		}
-
-		log.Printf("key %s terminated\n", key.Name)
 	}
 
 	log.Println("Completed DO Janitor")

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -213,7 +213,7 @@ func keyList(ctx context.Context, client *godo.Client) ([]godo.Key, error) {
     opt := &godo.ListOptions{}
     for {
         keys, resp, err := client.Key.List(ctx, opt)
-        if err ! nil {
+        if err != nil {
             return nil, err
         }
 

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -110,6 +111,14 @@ func main() {
 	}
 
 	for _, key := range keys {
+		// we only care to delete keys that start with "capdo"
+		match, err := regexp.MatchString(`^capdo`, key.Name)
+		if match != true {
+			continue
+		}
+		if err != nil {
+			log.Fatalf("failed to match against key name %s: %+v\n", key.Name, err.Error())
+		}
 		_, err := client.Keys.DeleteByID(ctx, key.ID)
 		if err != nil {
 			log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -13,13 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package main
 
 import (
 	"context"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -109,16 +109,15 @@ func main() {
 		log.Fatalf("failed to list keys: %+v", err.Error())
 	}
 
-	capdoStr := "capdo" // using this for repeated comparisons in the loop below
 	for _, key := range keys {
-		// we only care to cleanup keys that start with "capdo"
-		if len(key.Name) >= len(capdoStr) && key.Name[0:len(capdoStr)] == capdoStr {
-			log.Printf("%s contains capdo at the start of it's name so it's safe to terminate\n", key.Name)
+		if strings.HasPrefix(key.Name, "capdo-") {
+			log.Printf("%s contains capdo prefix so it's safe to terminate\n", key.Name)
 			_, err := client.Keys.DeleteByID(ctx, key.ID)
 			if err != nil {
 				log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
 				continue
 			}
+
 			log.Printf("key %s terminated\n", key.Name)
 		}
 	}

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/digitalocean/godo"

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -119,7 +119,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to match against key name %s: %+v\n", key.Name, err.Error())
 		}
-		_, err := client.Keys.DeleteByID(ctx, key.ID)
+		_, err = client.Keys.DeleteByID(ctx, key.ID)
 		if err != nil {
 			log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
 			continue

--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -104,20 +104,20 @@ func main() {
 		}
 	}
 
-    keys, err := keyList(ctx, client)
-    if err != nil {
-        log.Fatalf("failed to list keys: %+v", err.Error())
-    }
+	keys, err := keyList(ctx, client)
+	if err != nil {
+		log.Fatalf("failed to list keys: %+v", err.Error())
+	}
 
-    for _, key := range keys {
-        _, err := client.Key.DeleteByID(ctx, key.ID)
-        if err != nil {
-            log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
-            continue
-        }
+	for _, key := range keys {
+		_, err := client.Keys.DeleteByID(ctx, key.ID)
+		if err != nil {
+			log.Printf("failed to delete key %s: %+v\n", key.Name, err.Error())
+			continue
+		}
 
-        log.Printf("key %s terminated\n", key.Name)
-    }
+		log.Printf("key %s terminated\n", key.Name)
+	}
 
 	log.Println("Completed DO Janitor")
 	os.Exit(0)
@@ -207,29 +207,29 @@ func volumeList(ctx context.Context, client *godo.Client) ([]godo.Volume, error)
 }
 
 func keyList(ctx context.Context, client *godo.Client) ([]godo.Key, error) {
-    list := []godo.Key{}
+	list := []godo.Key{}
 
-    // create options. initially, these will be blank.
-    opt := &godo.ListOptions{}
-    for {
-        keys, resp, err := client.Key.List(ctx, opt)
-        if err != nil {
-            return nil, err
-        }
+	// create options. initially, these will be blank.
+	opt := &godo.ListOptions{}
+	for {
+		keys, resp, err := client.Keys.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
 
-        list = append(list, keys...)
+		list = append(list, keys...)
 
-        if resp.Links == nil || resp.Links.IsLastPage() {
-            break
-        }
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
 
-        page, err := resp.Links.CurrentPage()
-        if err != nil {
-            return nil, err
-        }
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
 
-        opt.ListOptions.Page = page + 1
-    }
+		opt.Page = page + 1
+	}
 
-    return list, nil
+	return list, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up ssh keys from our DO test account whenever do-janitor is called.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #238 

**Special notes for your reviewer**:
Not 100% sure how this will work since I'm not able to compare a `createdAt` time value to the `timeToCleanInHours` value we'd typically use within do-janitor (godo.Key does not have this as an available field nor does it seem to ever set one implicitly somewhere). It seems like we only run do-janitor when we want to clean up old resources in the DO account. The only problem I can think of is if we want there to be some longstanding ssh keys to exist within the DO account (outside of these ephemeral e2e test keys). Then this code would likely delete them every time do-janitor is ran. But hard to tell for sure unless I can manually test this.

Any recommendations for how I can test this change (safely)? @timoreimann @cpanato 

Also, is this issue still an issue? Or is it stale at this point. I don't see any left over keys in the account aside from some created by other co-maintainers.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```