### PR TITLE
Switch to non-preformatted etcd DOBS volumes

### DIFF
--- a/templates/cluster-template-ext-etcd-storage.yaml
+++ b/templates/cluster-template-ext-etcd-storage.yaml
@@ -50,6 +50,12 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddata/etcd
+    diskSetup:
+      filesystems:
+        - device: /dev/sda
+          filesystem: ext4
+          label: etcd_data
+          partition: "none"
     mounts:
       - - LABEL=etcd_data
         - /var/lib/etcddata
@@ -66,8 +72,6 @@ spec:
       dataDisks:
       - diskSizeGB: 256
         nameSuffix: etcd
-        filesystemType: ext4
-        filesystemLabel: etcd_data
       size: "${DO_CONTROL_PLANE_MACHINE_TYPE}"
       image: ${DO_CONTROL_PLANE_MACHINE_IMAGE}
       sshKeys:


### PR DESCRIPTION
**What this PR does / why we need it**:
Preformatted disks in DOBS are formatted by the droplet OS after the disk is attached to the droplet and get automounted afterwards. This is a race condition between the formatting part and the remount that capi does. In error cases you could end up with a crashing formatter that leaves you with a tiny initial FS that is not grown to the specified value.

In order to avoid this, we need to switch to non-preformatted disks and let capi take care of FS creation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```