### PR TITLE
Retag DO LB and droplets upon migration to another management cluster

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -30,4 +30,5 @@ type DOClients struct {
 	Keys          godo.KeysService
 	LoadBalancers godo.LoadBalancersService
 	Domains       godo.DomainsService
+	Tags          godo.TagsService
 }

--- a/cloud/services/computes/tags.go
+++ b/cloud/services/computes/tags.go
@@ -1,0 +1,76 @@
+package computes
+
+import (
+	"github.com/digitalocean/godo"
+	"k8s.io/apimachinery/pkg/api/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-digitalocean/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-digitalocean/cloud/scope"
+	"strconv"
+)
+
+func (s *Service) Retag(droplet *godo.Droplet, scope *scope.MachineScope) error {
+	tags := infrav1.BuildTags(infrav1.BuildTagParams{
+		ClusterName: infrav1.DOSafeName(s.scope.Name()),
+		ClusterUID:  s.scope.UID(),
+		Name:        infrav1.DOSafeName(scope.Name()),
+		Role:        scope.Role(),
+		Additional:  scope.AdditionalTags(),
+	})
+
+	for _, tag := range tags {
+		if !contains(droplet.Tags, tag) {
+			if err := s.createTag(tag); err != nil {
+				return err
+			}
+			_, err := s.scope.Tags.TagResources(s.ctx, tag, &godo.TagResourcesRequest{
+				Resources: []godo.Resource{
+					{
+						ID:   strconv.Itoa(droplet.ID),
+						Type: godo.DropletResourceType,
+					},
+				},
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// do we ever add tags to CPC droplets in another way or manually that might be deleted by the below logic?
+	for _, t := range droplet.Tags {
+		if !contains(tags, t) {
+			_, err := s.scope.Tags.UntagResources(s.ctx, t, &godo.UntagResourcesRequest{
+				Resources: []godo.Resource{
+					{
+						ID:   strconv.Itoa(droplet.ID),
+						Type: godo.DropletResourceType,
+					},
+				},
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) createTag(tag string) error {
+	_, _, err := s.scope.Tags.Get(s.ctx, tag)
+	switch {
+	case errors.IsNotFound(err):
+		_, _, err := s.scope.Tags.Create(s.ctx, &godo.TagCreateRequest{Name: tag})
+		return err
+	default:
+		return err
+	}
+}
+
+func contains(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}

--- a/cloud/services/networking/loadbalancers.go
+++ b/cloud/services/networking/loadbalancers.go
@@ -52,13 +52,13 @@ func (s *Service) CreateLoadBalancer(spec *infrav1.DOLoadBalancer) (*godo.LoadBa
 	return lb, nil
 }
 
-// NeedsUpdate checks if the load balancer needs to be updated
-// Example: for a migrated docluster, the LB name and tag needs to be updated to reflect the new capi cluster's uid
+// NeedsUpdate checks if the load balancer needs to be updated.
+// Example: for a migrated docluster, the LB name and tag needs to be updated to reflect the new capi cluster's uid.
 func (s *Service) NeedsUpdate(lb *godo.LoadBalancer) bool {
-	return lb.Tag != infrav1.ClusterNameUIDRoleTag(infrav1.DOSafeName(s.scope.Name()), s.scope.UID(), infrav1.APIServerRoleTagValue)
+	return lb.Tag != s.getLBTag()
 }
 
-// UpdateLoadBalancer updates the existing lb
+// UpdateLoadBalancer updates the existing lb.
 func (s *Service) UpdateLoadBalancer(oldLB *godo.LoadBalancer, spec *infrav1.DOLoadBalancer) (*godo.LoadBalancer, error) {
 	request := s.loadBalancerRequest(spec)
 	lb, _, err := s.scope.LoadBalancers.Update(s.ctx, oldLB.ID, request)
@@ -100,8 +100,12 @@ func (s *Service) loadBalancerRequest(spec *infrav1.DOLoadBalancer) *godo.LoadBa
 			UnhealthyThreshold:     spec.HealthCheck.UnhealthyThreshold,
 			HealthyThreshold:       spec.HealthCheck.HealthyThreshold,
 		},
-		Tag:     infrav1.ClusterNameUIDRoleTag(clusterName, s.scope.UID(), infrav1.APIServerRoleTagValue),
+		Tag:     s.getLBTag(),
 		VPCUUID: s.scope.VPC().VPCUUID,
 	}
 	return request
+}
+
+func (s *Service) getLBTag() string {
+	return infrav1.ClusterNameUIDRoleTag(infrav1.DOSafeName(s.scope.Name()), s.scope.UID(), infrav1.APIServerRoleTagValue)
 }

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -162,6 +162,14 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 		}
 
 		r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerCreated", "Created new load balancers - %s", loadbalancer.Name)
+	} else {
+		if networkingsvc.NeedsUpdate(loadbalancer) {
+			loadbalancer, err = networkingsvc.UpdateLoadBalancer(loadbalancer, apiServerLoadbalancer)
+			if err != nil {
+				return reconcile.Result{}, errors.Wrapf(err, "failed to update load balancer for DOCluster %s/%s", docluster.Namespace, docluster.Name)
+			}
+			r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerUpdated", "Updated existing load balancers - %s", loadbalancer.Name)
+		}
 	}
 
 	apiServerLoadbalancerRef.ResourceID = loadbalancer.ID

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -162,14 +162,17 @@ func (r *DOClusterReconciler) reconcile(ctx context.Context, clusterScope *scope
 		}
 
 		r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerCreated", "Created new load balancers - %s", loadbalancer.Name)
-	} else {
-		if networkingsvc.NeedsUpdate(loadbalancer) {
-			loadbalancer, err = networkingsvc.UpdateLoadBalancer(loadbalancer, apiServerLoadbalancer)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to update load balancer for DOCluster %s/%s", docluster.Namespace, docluster.Name)
-			}
-			r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerUpdated", "Updated existing load balancers - %s", loadbalancer.Name)
+	} else if networkingsvc.NeedsUpdate(loadbalancer) {
+		lb := loadbalancer
+		loadbalancer, err = networkingsvc.UpdateLoadBalancer(lb, apiServerLoadbalancer)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "failed to update load balancer %s for DOCluster %s/%s",
+				lb.ID,
+				docluster.Namespace,
+				docluster.Name,
+			)
 		}
+		r.Recorder.Eventf(docluster, corev1.EventTypeNormal, "LoadBalancerUpdated", "Updated existing load balancers - %s", loadbalancer.Name)
 	}
 
 	apiServerLoadbalancerRef.ResourceID = loadbalancer.ID

--- a/controllers/domachine_controller.go
+++ b/controllers/domachine_controller.go
@@ -283,6 +283,14 @@ func (r *DOMachineReconciler) reconcile(ctx context.Context, machineScope *scope
 			return reconcile.Result{}, err
 		}
 		r.Recorder.Eventf(domachine, corev1.EventTypeNormal, "InstanceCreated", "Created new droplet instance - %s", droplet.Name)
+	} else {
+		// do we want to retag control plane and worker capi droplets?
+		err := computesvc.Retag(droplet, machineScope)
+		if err != nil {
+			err = errors.Errorf("Failed to retag droplet instance %d for DOMachine %s/%s: %v", droplet.ID, domachine.Namespace, domachine.Name, err)
+			r.Recorder.Event(domachine, corev1.EventTypeWarning, "InstanceRetaggingError", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	machineScope.SetProviderID(strconv.Itoa(droplet.ID))

--- a/controllers/domachine_controller.go
+++ b/controllers/domachine_controller.go
@@ -284,7 +284,6 @@ func (r *DOMachineReconciler) reconcile(ctx context.Context, machineScope *scope
 		}
 		r.Recorder.Eventf(domachine, corev1.EventTypeNormal, "InstanceCreated", "Created new droplet instance - %s", droplet.Name)
 	} else {
-		// do we want to retag control plane and worker capi droplets?
 		err := computesvc.Retag(droplet, machineScope)
 		if err != nil {
 			err = errors.Errorf("Failed to retag droplet instance %d for DOMachine %s/%s: %v", droplet.ID, domachine.Namespace, domachine.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #445 

**Special notes for your reviewer**:
I've added comments in the code in a couple of places that I need your input on.
Questions:
1. The docluster controller and domachine controller run independently of each other. A situation may arise where a DO LB is retagged but the control plane droplets are not yet retagged. This will cause downtime until the domachine reconciles at least one control plane droplet. Any way around this?
2. Can this happen? All the control plane droplets are retagged but the LB is not yet retagged

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
1. Retag DO LB and droplets upon migration of DOCluster to another management cluster. 
```