### PR TITLE
Update co-maintainers file to make Ingo Gottwald a co-maintainer and remove myself and add my name to emeritus approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,3 +12,4 @@ reviewers:
 
 emeritus_approvers:
   - xmudrii
+  - MorrisLaw

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,6 @@ aliases:
 
   cluster-api-do-maintainers:
     - cpanato
-    - MorrisLaw
+    - gottwald
     - prksu
     - timoreimann


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm leaving DigitalOcean and moving on to another company. I won't be contributing to this much at all with the new switch so I'm proposing @gottwald to take my place as co-maintainer because he still contributes to the project actively and has a good understanding of the project overall.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```