### PR TITLE
not fail the command if is not able to delete the key

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -48,7 +48,7 @@ create_ssh_key() {
 remove_ssh_key() {
     local ssh_fingerprint=$1
     echo "removing ssh key"
-    doctl compute ssh-key delete ${ssh_fingerprint} --force
+    doctl compute ssh-key delete ${ssh_fingerprint} --force || true
     rm -f ${SSH_KEY_PATH}
 
     ${REPO_ROOT}/hack/log/redact.sh || true

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -45,7 +45,7 @@ create_ssh_key() {
 remove_ssh_key() {
     local ssh_fingerprint=$1
     echo "removing ssh key"
-    doctl compute ssh-key delete ${ssh_fingerprint} --force
+    doctl compute ssh-key delete ${ssh_fingerprint} --force || true
     rm -f ${SSH_KEY_PATH}
 
     ${REPO_ROOT}/hack/log/redact.sh || true


### PR DESCRIPTION
**What this PR does / why we need it**:
- not fail the command if is not able to delete the key
we have a janitor job that will clean that eventually so we dont need to fail the job if cannot delete the key

/assign @gottwald @timoreimann 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/8784

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```