### PR TITLE
add github actions to run golangci-lint  and update Go to 1.19.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,12 @@ updates:
       - "area/dependency"
       - "release-note-none"
       - "ok-to-test"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.19"
+          check-latest: true
+          cache: false
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: "v1.52"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - depguard
   - dogsled
   - errcheck
   - exportloopref

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.19.10@sha256:83f9f840072d05ad4d90ce4ac7cb2427632d6b89d5ffc558f18f9577ec8188c0 as builder
+FROM golang:1.19.12@sha256:d680597c753e7c73814ddd09c69bef5b78922d81d3ca103c82fa69771ea8151c as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ ENVSUBST_VER := v1.2.0
 ENVSUBST_BIN := envsubst
 ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)
 
-GOLANGCI_LINT_VER := v1.50.1
+GOLANGCI_LINT_VER := v1.52.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
@@ -303,7 +303,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	docker pull docker/dockerfile:1.1-experimental
-	docker pull docker.io/library/golang:1.19.10
+	docker pull docker.io/library/golang:1.19.12
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build
@@ -391,7 +391,7 @@ release-binary: $(RELEASE_DIR)
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace" \
 		-w /workspace \
-		golang:1.19.10 \
+		golang:1.19.12 \
 		go build -a -trimpath -ldflags '-extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ $(ARTIFACTS):
 	mkdir -p $@
 
 .PHONY: test
-test: generate lint ## Run tests
+test: generate ## Run tests
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -covermode=atomic -coverprofile=coverage.tmp.out ./api/... ./controllers/... ./cloud/...
 	@cat coverage.tmp.out | grep -v "generated" > coverage.out
 	@rm coverage.tmp.out

--- a/controllers/docluster_controller.go
+++ b/controllers/docluster_controller.go
@@ -53,7 +53,7 @@ type DOClusterReconciler struct {
 	ReconcileTimeout time.Duration
 }
 
-func (r *DOClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *DOClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, _ controller.Options) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.DOCluster{}).
 		WithEventFilter(predicates.ResourceNotPaused(ctrl.LoggerFrom(ctx))). // don't queue reconcile if resource is paused

--- a/controllers/domachine_controller.go
+++ b/controllers/domachine_controller.go
@@ -55,7 +55,7 @@ type DOMachineReconciler struct {
 	ReconcileTimeout time.Duration
 }
 
-func (r *DOMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *DOMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, _ controller.Options) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.DOMachine{}).
 		WithEventFilter(predicates.ResourceNotPaused(ctrl.LoggerFrom(ctx))). // don't queue reconcile if resource is paused

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -26,4 +26,4 @@ cd "${REPO_ROOT}" && \
 	source ./scripts/fetch_ext_bins.sh && \
 	fetch_tools && \
 	setup_envs && \
-	make generate lint test
+	make test

--- a/util/dns/resolver/faker.go
+++ b/util/dns/resolver/faker.go
@@ -31,7 +31,7 @@ func NewFakeDNSResolver(expectedMsg []*dns.Msg) *FakeDNSResolver {
 	}
 }
 
-func (f *FakeDNSResolver) Query(servers []string, msg *dns.Msg) (*dns.Msg, error) {
+func (f *FakeDNSResolver) Query(_ []string, msg *dns.Msg) (*dns.Msg, error) {
 	if len(f.expectedMsg) <= f.c {
 		return msg, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- add github actions to run golangci-lint  and update Go to 1.19.12

other providers are using GH action for small jobs, the lint is a quick one and very useful 

/assign @timoreimann @gottwald

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
add github actions to run golangci-lint  and update Go to 1.19.12
```