### PR TITLE
janitor: fix listing

### DIFF
--- a/hack/do-janitor/do-janitor.go
+++ b/hack/do-janitor/do-janitor.go
@@ -187,7 +187,9 @@ func volumeList(ctx context.Context, client *godo.Client) ([]godo.Volume, error)
 	list := []godo.Volume{}
 
 	// create options. initially, these will be blank
-	opt := &godo.ListVolumeParams{}
+	opt := &godo.ListVolumeParams{
+		ListOptions: &godo.ListOptions{},
+	}
 	for {
 		volumes, resp, err := client.Storage.ListVolumes(ctx, opt)
 		if err != nil {


### PR DESCRIPTION
The nested `ListOptions` struct is a pointer that needs to be initialized. Otherwise, the code will crash with a nil pointer exception when incrementing the page. This has been happening for a while: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-digitalocean-janitor/1831360184321052672

```release-note
NONE
```