### PR TITLE
Updated K8s version and fix url in getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,7 +89,7 @@ Generate templates for creating workload clusters:
 ```bash
 $ clusterctl generate cluster capdo-quickstart \
     --infrastructure digitalocean \
-    --kubernetes-version v1.17.11 \
+    --kubernetes-version v1.32.0 \
     --control-plane-machine-count 1 \
     --worker-machine-count 3 > capdo-quickstart-cluster.yaml
 ```
@@ -152,7 +152,7 @@ $ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://docs.projectca
 $ KUBECONFIG=capdo-quickstart.kubeconfig kubectl create secret generic digitalocean --namespace kube-system --from-literal access-token=$DIGITALOCEAN_ACCESS_TOKEN
 
 # Deploy DigitalOcean Cloud Controller Manager
-$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/v0.1.27.yml
+$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.62.yml
 
 # Deploy DigitalOcean CSI (optional)
 $ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.3.0.yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,7 +155,9 @@ $ KUBECONFIG=capdo-quickstart.kubeconfig kubectl create secret generic digitaloc
 $ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/digitalocean-cloud-controller-manager/v0.1.62.yml
 
 # Deploy DigitalOcean CSI (optional)
-$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.3.0.yaml
+$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/v4.14.0/deploy/kubernetes/releases/csi-digitalocean-v4.14.0/crds.yaml
+$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/v4.14.0/deploy/kubernetes/releases/csi-digitalocean-v4.14.0/driver.yaml
+$ KUBECONFIG=capdo-quickstart.kubeconfig kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/v4.14.0/deploy/kubernetes/releases/csi-digitalocean-v4.14.0/snapshot-controller.yaml
 ```
 
 After the [CNI](https://github.com/containernetworking/cni) and the [CCM](https://github.com/digitalocean/digitalocean-cloud-controller-manager) have deployed your workload cluster nodes should be in the `ready` state. You can verify this by using:


### PR DESCRIPTION
**What this PR does / why we need it**:

I was trying out the [getting started guide](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/tree/main/docs) and noticed the following:
- The Kubernetes version in the `clusterctl generate cluster` command is outdated. If you try to run this today you'll face issues with kubeadm init. I wasn't able to capture the exact kubeadm error, but upgrading the version fixed the kubeadm errors.
- The release manifest url for digitalocean-cloud-controller-manager was also incorrect. This PR updates this to the latest version as well.

**Special notes for your reviewer**:

CC: @gottwald @varshavaradarajan 

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

No docs changes needed here, the changes are only to the getting started guide.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```