### PR TITLE
Minimize droplet API requests

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -185,6 +185,11 @@ func (m *MachineScope) SetInstanceStatus(v infrav1.DOResourceStatus) {
 	m.DOMachine.Status.InstanceStatus = &v
 }
 
+// IsReady returns the DOMachine Ready Status.
+func (m *MachineScope) IsReady() bool {
+	return m.DOMachine.Status.Ready
+}
+
 // SetReady sets the DOMachine Ready Status.
 func (m *MachineScope) SetReady() {
 	m.DOMachine.Status.Ready = true

--- a/internal/controller/domachine_controller.go
+++ b/internal/controller/domachine_controller.go
@@ -260,6 +260,14 @@ func (r *DOMachineReconciler) reconcile(ctx context.Context, machineScope *scope
 		return result, fmt.Errorf("failed to reconcile volumes: %w", err)
 	}
 
+	// Once a droplet is marked active, it should never switch to a different
+	// state again (other than archived, which is handled by the delete
+	// reconciler). Return early in this case to skip doing unnecessary API
+	// requests.
+	if machineScope.IsReady() {
+		return reconcile.Result{}, nil
+	}
+
 	computesvc := computes.NewService(ctx, clusterScope)
 	droplet, err := computesvc.GetDroplet(machineScope.GetInstanceID())
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip reaching out to the DO API when a machine is already considered ready. This should be okay since active droplets stay in that state until deleted, which is handled by a different code path.

This commit has been cherry-picked from an internal fork which had patches that'd be relevant in upstream as well. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```